### PR TITLE
feat: add armor and item textures

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Three.js powered Minecraft skin viewer.
 * Elytras
 * Slim Arms
   * Automatic model detection (Slim / Default)
+* Armor
+* Hand-held items
 * FXAA (fast approximate anti-aliasing)
 
 # Usage
@@ -27,11 +29,13 @@ Three.js powered Minecraft skin viewer.
 <canvas id="skin_container"></canvas>
 <script>
 	let skinViewer = new skinview3d.SkinViewer({
-		canvas: document.getElementById("skin_container"),
-		width: 300,
-		height: 400,
-		skin: "img/skin.png"
-	});
+                canvas: document.getElementById("skin_container"),
+                width: 300,
+                height: 400,
+                skin: "img/skin.png",
+                armor: "img/armor.png",
+                item: "img/item.png"
+        });
 
 	// Change viewer size
 	skinViewer.width = 600;
@@ -40,8 +44,14 @@ Three.js powered Minecraft skin viewer.
 	// Load another skin
 	skinViewer.loadSkin("img/skin2.png");
 
-	// Load a cape
-	skinViewer.loadCape("img/cape.png");
+        // Load a cape
+        skinViewer.loadCape("img/cape.png");
+
+        // Load armor
+        skinViewer.loadArmor("img/armor.png");
+
+        // Load an item from a URL
+        skinViewer.loadItem("https://example.com/item.png");
 
 	// Load an elytra (from a cape texture)
 	skinViewer.loadCape("img/cape.png", { backEquipment: "elytra" });

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -170,6 +170,20 @@ export interface SkinViewerOptions {
 		  };
 
 	/**
+	 * The armor texture of the player.
+	 *
+	 * @defaultValue If unspecified, the skin's outer layer will be used.
+	 */
+	armor?: RemoteImage | TextureSource;
+
+	/**
+	 * The item texture to display in the player's right hand.
+	 *
+	 * @defaultValue If unspecified, no item will be displayed.
+	 */
+	item?: RemoteImage | TextureSource;
+
+	/**
 	 * Whether to preserve the buffers until manually cleared or overwritten.
 	 *
 	 * @defaultValue `false`
@@ -291,9 +305,13 @@ export class SkinViewer {
 	readonly skinCanvas: HTMLCanvasElement;
 	readonly capeCanvas: HTMLCanvasElement;
 	readonly earsCanvas: HTMLCanvasElement;
+	readonly armorCanvas: HTMLCanvasElement;
+	readonly itemCanvas: HTMLCanvasElement;
 	private skinTexture: Texture | null = null;
 	private capeTexture: Texture | null = null;
 	private earsTexture: Texture | null = null;
+	private armorTexture: Texture | null = null;
+	private itemTexture: Texture | null = null;
 	private backgroundTexture: Texture | null = null;
 
 	private _disposed: boolean = false;
@@ -335,6 +353,8 @@ export class SkinViewer {
 		this.skinCanvas = document.createElement("canvas");
 		this.capeCanvas = document.createElement("canvas");
 		this.earsCanvas = document.createElement("canvas");
+		this.armorCanvas = document.createElement("canvas");
+		this.itemCanvas = document.createElement("canvas");
 
 		this.scene = new Scene();
 		this.camera = new PerspectiveCamera();
@@ -414,6 +434,12 @@ export class SkinViewer {
 			this.loadEars(options.ears.source, {
 				textureType: options.ears.textureType,
 			});
+		}
+		if (options.armor !== undefined) {
+			this.loadArmor(options.armor);
+		}
+		if (options.item !== undefined) {
+			this.loadItem(options.item);
 		}
 		if (options.width !== undefined) {
 			this.width = options.width;
@@ -534,6 +560,26 @@ export class SkinViewer {
 		this.playerObject.ears.map = this.earsTexture;
 	}
 
+	private recreateArmorTexture(): void {
+		if (this.armorTexture !== null) {
+			this.armorTexture.dispose();
+		}
+		this.armorTexture = new CanvasTexture(this.armorCanvas);
+		this.armorTexture.magFilter = NearestFilter;
+		this.armorTexture.minFilter = NearestFilter;
+		this.playerObject.skin.outerLayerMap = this.armorTexture;
+	}
+
+	private recreateItemTexture(): void {
+		if (this.itemTexture !== null) {
+			this.itemTexture.dispose();
+		}
+		this.itemTexture = new CanvasTexture(this.itemCanvas);
+		this.itemTexture.magFilter = NearestFilter;
+		this.itemTexture.minFilter = NearestFilter;
+		this.playerObject.item.map = this.itemTexture;
+	}
+
 	loadSkin(empty: null): void;
 	loadSkin<S extends TextureSource | RemoteImage>(
 		source: S,
@@ -640,6 +686,73 @@ export class SkinViewer {
 		if (this.earsTexture !== null) {
 			this.earsTexture.dispose();
 			this.earsTexture = null;
+		}
+	}
+
+	loadArmor(empty: null): void;
+	loadArmor<S extends TextureSource | RemoteImage>(
+		source: S,
+		options?: LoadOptions
+	): S extends TextureSource ? void : Promise<void>;
+
+	loadArmor(source: TextureSource | RemoteImage | null, options: LoadOptions = {}): void | Promise<void> {
+		if (source === null) {
+			this.resetArmor();
+		} else if (isTextureSource(source)) {
+			loadSkinToCanvas(this.armorCanvas, source);
+			this.recreateArmorTexture();
+
+			this.playerObject.skin.setOuterLayerVisible(options.makeVisible !== false);
+		} else {
+			return loadImage(source).then(image => this.loadArmor(image, options));
+		}
+	}
+
+	resetArmor(): void {
+		this.playerObject.skin.setOuterLayerVisible(false);
+		this.playerObject.skin.outerLayerMap = null;
+		if (this.armorTexture !== null) {
+			this.armorTexture.dispose();
+			this.armorTexture = null;
+		}
+	}
+
+	loadItem(empty: null): void;
+	loadItem<S extends TextureSource | RemoteImage>(
+		source: S,
+		options?: LoadOptions
+	): S extends TextureSource ? void : Promise<void>;
+
+	loadItem(source: TextureSource | RemoteImage | null, options: LoadOptions = {}): void | Promise<void> {
+		if (source === null) {
+			this.resetItem();
+		} else if (isTextureSource(source)) {
+			const ctx = this.itemCanvas.getContext("2d");
+			if (ctx === null) {
+				throw new Error("Failed to get 2D context");
+			}
+			const width = (source as any).width ?? 16;
+			const height = (source as any).height ?? 16;
+			this.itemCanvas.width = width;
+			this.itemCanvas.height = height;
+			ctx.clearRect(0, 0, width, height);
+			ctx.drawImage(source as CanvasImageSource, 0, 0, width, height);
+			this.recreateItemTexture();
+
+			if (options.makeVisible !== false) {
+				this.playerObject.item.visible = true;
+			}
+		} else {
+			return loadImage(source).then(image => this.loadItem(image, options));
+		}
+	}
+
+	resetItem(): void {
+		this.playerObject.item.visible = false;
+		this.playerObject.item.map = null;
+		if (this.itemTexture !== null) {
+			this.itemTexture.dispose();
+			this.itemTexture = null;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- allow separate armor textures on the player's outer layer
- support displaying a hand-held item texture
- document armor and item usage in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689354988f0c8327bf3163b6718e044d