### PR TITLE
Fix BendAnimation limb directions for visibility

### DIFF
--- a/src/animation.ts
+++ b/src/animation.ts
@@ -413,8 +413,8 @@ export class BendAnimation extends PlayerAnimation {
 	protected animate(player: PlayerObject): void {
 		const s = Math.sin(this.progress * 2 * Math.PI);
 		player.skin.leftArm.rotation.x = s * this.armBend;
-		player.skin.rightArm.rotation.x = s * this.armBend;
-		player.skin.leftLeg.rotation.x = s * this.legBend;
+		player.skin.rightArm.rotation.x = -s * this.armBend;
+		player.skin.leftLeg.rotation.x = -s * this.legBend;
 		player.skin.rightLeg.rotation.x = s * this.legBend;
 	}
 }


### PR DESCRIPTION
## Summary
- make BendAnimation bend limbs in opposite directions so the motion is visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893b8e0ccc88327a4c1e9d13729e12c