### PR TITLE
feat: add animation editor toggle

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -23,6 +23,11 @@
 				align-self: flex-start;
 			}
 
+			#skin_container.expanded {
+				width: 800px;
+				height: 600px;
+			}
+
 			.controls {
 				flex: 1;
 				overflow-y: auto;
@@ -80,6 +85,15 @@
 
 		<div class="controls">
 			<button id="reset_all" type="button" class="control">Reset All</button>
+
+			<div class="control-section">
+				<h1>Animation Editor</h1>
+				<button id="toggle_editor" type="button" class="control">Create Animation</button>
+				<div id="animation_editor" class="hidden">
+					<div id="timeline"></div>
+					<button id="add_keyframe" type="button" class="control">Add Keyframe</button>
+				</div>
+			</div>
 
 			<div class="control-section">
 				<h1>Viewport</h1>

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -1,6 +1,8 @@
 import * as skinview3d from "../src/skinview3d";
 import type { ModelType } from "skinview-utils";
 import type { BackEquipment } from "../src/model";
+import { TransformControls } from "three/examples/jsm/controls/TransformControls.js";
+import { Euler, Vector3 } from "three";
 import "./style.css";
 
 const skinParts = ["head", "body", "rightArm", "leftArm", "rightLeg", "leftLeg"];
@@ -17,6 +19,11 @@ const availableAnimations = {
 };
 
 let skinViewer: skinview3d.SkinViewer;
+let transformControls: TransformControls | null = null;
+const keyframes: Array<{ time: number; position: Vector3; rotation: Euler }> = [];
+let editorEnabled = false;
+let previousAutoRotate = false;
+let previousAnimationPaused = false;
 
 function obtainTextureUrl(id: string): string {
 	const urlInput = document.getElementById(id) as HTMLInputElement;
@@ -513,3 +520,72 @@ function initializeViewer(): void {
 
 initializeViewer();
 initializeControls();
+
+function toggleEditor(): void {
+	const editor = document.getElementById("animation_editor");
+	const skinContainer = document.getElementById("skin_container") as HTMLCanvasElement;
+	const canvasWidth = document.getElementById("canvas_width") as HTMLInputElement;
+	const canvasHeight = document.getElementById("canvas_height") as HTMLInputElement;
+	if (!editor || !skinContainer) {
+		return;
+	}
+
+	editorEnabled = !editorEnabled;
+	editor.classList.toggle("hidden", !editorEnabled);
+
+	if (editorEnabled) {
+		previousAutoRotate = skinViewer.autoRotate;
+		previousAnimationPaused = skinViewer.animation?.paused ?? false;
+		skinViewer.autoRotate = false;
+		if (skinViewer.animation) {
+			skinViewer.animation.paused = true;
+		}
+
+		skinContainer.classList.add("expanded");
+		skinViewer.width = 800;
+		skinViewer.height = 600;
+
+		transformControls = new TransformControls(skinViewer.camera, skinViewer.renderer.domElement);
+		transformControls.addEventListener("dragging-changed", (e: { value: boolean }) => {
+			skinViewer.controls.enabled = !e.value;
+		});
+		transformControls.attach(skinViewer.playerObject);
+		skinViewer.scene.add(transformControls);
+	} else {
+		skinViewer.autoRotate = previousAutoRotate;
+		if (skinViewer.animation) {
+			skinViewer.animation.paused = previousAnimationPaused;
+		}
+
+		skinContainer.classList.remove("expanded");
+		if (canvasWidth && canvasHeight) {
+			skinViewer.width = Number(canvasWidth.value);
+			skinViewer.height = Number(canvasHeight.value);
+		}
+
+		if (transformControls) {
+			skinViewer.scene.remove(transformControls);
+			transformControls.dispose();
+			transformControls = null;
+		}
+	}
+}
+
+function addKeyframe(): void {
+	keyframes.push({
+		time: Date.now(),
+		position: skinViewer.playerObject.position.clone(),
+		rotation: skinViewer.playerObject.rotation.clone(),
+	});
+	const timeline = document.getElementById("timeline");
+	if (timeline) {
+		const entry = document.createElement("div");
+		entry.textContent = `Keyframe ${keyframes.length}`;
+		timeline.appendChild(entry);
+	}
+}
+
+const toggleEditorBtn = document.getElementById("toggle_editor");
+toggleEditorBtn?.addEventListener("click", toggleEditor);
+const addKeyframeBtn = document.getElementById("add_keyframe");
+addKeyframeBtn?.addEventListener("click", addKeyframe);


### PR DESCRIPTION
## Summary
- add Animation Editor control section with Create Animation toggle
- open editor panel with TransformControls, pausing animations
- allow adding simple keyframes while reusing existing OrbitControls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ca8f6060832791e1642a5563851c