### PR TITLE
feat(examples): add keyframe animation JSON import/export

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -92,6 +92,8 @@
 				<div id="animation_editor" class="hidden">
 					<div id="timeline"></div>
 					<button id="add_keyframe" type="button" class="control">Add Keyframe</button>
+					<button id="download_json" type="button" class="control">Download JSON</button>
+					<input id="upload_json" type="file" class="control" accept="application/json" />
 				</div>
 			</div>
 


### PR DESCRIPTION
## Summary
- expose `KeyframeAnimation` JSON helpers in example
- allow downloading current keyframes to JSON
- allow uploading JSON animation and playing it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893cf23fd4c8327b83d64e87aa4806c