### PR TITLE
docs: explain resolveBone helper

### DIFF
--- a/src/animation.ts
+++ b/src/animation.ts
@@ -122,6 +122,10 @@ export interface KeyframeData {
 	keyframes: Keyframe[];
 }
 
+/**
+ * Resolve a dotted bone path (e.g. "skin.leftArm") to the corresponding object
+ * on the player model.
+ */
 function resolveBone(player: PlayerObject, path: string): any {
 	return path.split(".").reduce((obj: any, key: string) => obj?.[key], player as any);
 }


### PR DESCRIPTION
## Summary
- clarify how resolveBone traverses dotted bone paths for keyframe animations

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893fd3749e88327828bdf65d54e4d9f