### PR TITLE
Add CCDIKSolver IK chains and per-bone timeline viewer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,10 @@ Welcome to the SkinView3D project. These guidelines help contributors build the 
 - Respond to review feedback promptly and respectfully.
 
 Following these practices will keep the project healthy, extensible, and bug-free. Happy hacking!
+
+## Development Insights
+- Keyframes must map rotations to the correct bone path. A past bug stored all rotations under a generic `rotation` key, which broke uploaded animations.
+- The animation editor exposes elbow and knee joints; do not remove these options.
+- When improvements or bug fixes are made, document the lessons learned here so they aren't repeated.
+- CCDIKSolver integration relies on existing body part groups as bones. Ensure IK targets are included in the bone selector and keyframes capture all bones in a chain.
+- The timeline viewer displays keyframes per bone row. Avoid reverting to a single-row timeline.

--- a/examples/index.html
+++ b/examples/index.html
@@ -104,6 +104,15 @@
 							<option value="skin.rightLegKnee">skin.rightLegKnee</option>
 							<option value="skin.leftLeg">skin.leftLeg</option>
 							<option value="skin.leftLegKnee">skin.leftLegKnee</option>
+							<option value="ik.rightArm">IK: Right Arm</option>
+							<option value="ik.leftArm">IK: Left Arm</option>
+						</select>
+					</label>
+					<label class="control">
+						Mode:
+						<select id="transform_mode">
+							<option value="rotate">Rotate</option>
+							<option value="translate">Translate</option>
 						</select>
 					</label>
 					<div id="timeline"></div>

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -2,7 +2,8 @@ import * as skinview3d from "../src/skinview3d";
 import type { ModelType } from "skinview-utils";
 import type { BackEquipment } from "../src/model";
 import { TransformControls } from "three/examples/jsm/controls/TransformControls.js";
-import { Euler, Object3D, Vector3 } from "three";
+import { CCDIKSolver } from "three/examples/jsm/animation/CCDIKSolver.js";
+import { Euler, Object3D, Vector3, Skeleton, SkinnedMesh, BufferGeometry, MeshBasicMaterial } from "three";
 import "./style.css";
 import { GeneratedAnimation } from "./generated-animation";
 
@@ -29,10 +30,15 @@ let previousAutoRotate = false;
 let previousAnimationPaused = false;
 let loadedAnimation: skinview3d.Animation | null = null;
 let uploadStatusEl: HTMLElement | null = null;
+const ikChains: Record<string, { target: Object3D; solver: CCDIKSolver; bones: string[] }> = {};
+let ikUpdateId: number | null = null;
 
 function getBone(path: string): Object3D {
 	if (path === "playerObject") {
 		return skinViewer.playerObject;
+	}
+	if (path.startsWith("ik.")) {
+		return ikChains[path]?.target ?? skinViewer.playerObject;
 	}
 	return path.split(".").reduce((obj: any, part) => obj?.[part], skinViewer.playerObject) ?? skinViewer.playerObject;
 }
@@ -192,6 +198,58 @@ function reloadNameTag(): void {
 	} else {
 		skinViewer.nameTag = text;
 	}
+}
+
+function setupIK(): void {
+	for (const chain of Object.values(ikChains)) {
+		skinViewer.scene.remove(chain.target);
+	}
+	for (const key in ikChains) {
+		delete ikChains[key];
+	}
+	const skin: any = skinViewer.playerObject.skin;
+	const rTarget = new Object3D();
+	rTarget.position.copy(skin.rightArmLower.getWorldPosition(new Vector3()));
+	skinViewer.scene.add(rTarget);
+	const rBones = [skin.rightArm, skin.rightArmElbow, skin.rightArmLower, rTarget];
+	const rSkeleton = new Skeleton(rBones as any);
+	const rMesh = new SkinnedMesh(new BufferGeometry(), new MeshBasicMaterial());
+	rMesh.bind(rSkeleton);
+	const rSolver = new CCDIKSolver(rMesh, [
+		{ target: 3, effector: 2, links: [{ index: 1 }, { index: 0 }], iteration: 10 },
+	]);
+	ikChains["ik.rightArm"] = {
+		target: rTarget,
+		solver: rSolver,
+		bones: ["skin.rightArm", "skin.rightArmElbow", "skin.rightArmLower"],
+	};
+
+	const lTarget = new Object3D();
+	lTarget.position.copy(skin.leftArmLower.getWorldPosition(new Vector3()));
+	skinViewer.scene.add(lTarget);
+	const lBones = [skin.leftArm, skin.leftArmElbow, skin.leftArmLower, lTarget];
+	const lSkeleton = new Skeleton(lBones as any);
+	const lMesh = new SkinnedMesh(new BufferGeometry(), new MeshBasicMaterial());
+	lMesh.bind(lSkeleton);
+	const lSolver = new CCDIKSolver(lMesh, [
+		{ target: 3, effector: 2, links: [{ index: 1 }, { index: 0 }], iteration: 10 },
+	]);
+	ikChains["ik.leftArm"] = {
+		target: lTarget,
+		solver: lSolver,
+		bones: ["skin.leftArm", "skin.leftArmElbow", "skin.leftArmLower"],
+	};
+
+	if (ikUpdateId !== null) {
+		cancelAnimationFrame(ikUpdateId);
+	}
+	const update = () => {
+		for (const chain of Object.values(ikChains)) {
+			chain.solver.update();
+		}
+		ikUpdateId = requestAnimationFrame(update);
+	};
+	update();
 }
 
 function initializeControls(): void {
@@ -489,6 +547,8 @@ function initializeViewer(): void {
 		canvas: skinContainer,
 	});
 
+	setupIK();
+
 	const canvasWidth = document.getElementById("canvas_width") as HTMLInputElement;
 	const canvasHeight = document.getElementById("canvas_height") as HTMLInputElement;
 	const fov = document.getElementById("fov") as HTMLInputElement;
@@ -592,7 +652,18 @@ function toggleEditor(): void {
 		transformControls = new TransformControls(skinViewer.camera, skinViewer.renderer.domElement);
 		transformControls.addEventListener("dragging-changed", (e: { value: boolean }) => {
 			skinViewer.controls.enabled = !e.value;
+			if (!e.value) {
+				if (selectedBone.startsWith("ik.")) {
+					addIKKeyframe(selectedBone);
+				} else {
+					addKeyframe();
+				}
+			}
 		});
+		const modeSelector = document.getElementById("transform_mode") as HTMLSelectElement;
+		if (modeSelector) {
+			transformControls.setMode(modeSelector.value as any);
+		}
 		transformControls.attach(getBone(selectedBone));
 		skinViewer.scene.add(transformControls);
 	} else {
@@ -615,20 +686,69 @@ function toggleEditor(): void {
 	}
 }
 
-function addKeyframe(): void {
-	const bone = getBone(selectedBone);
+function updateTimeline(): void {
+	const timeline = document.getElementById("timeline");
+	if (!timeline) {
+		return;
+	}
+	timeline.innerHTML = "";
+	if (keyframes.length === 0) {
+		return;
+	}
+	const start = keyframes[0].time;
+	const end = keyframes[keyframes.length - 1].time;
+	const duration = end - start || 1;
+	const rows = new Map<string, HTMLDivElement>();
+	for (const kf of keyframes) {
+		let track = rows.get(kf.bone);
+		if (!track) {
+			const row = document.createElement("div");
+			row.className = "kf-row";
+			const label = document.createElement("span");
+			label.className = "kf-label";
+			label.textContent = kf.bone;
+			track = document.createElement("div");
+			track.className = "kf-track";
+			row.appendChild(label);
+			row.appendChild(track);
+			timeline.appendChild(row);
+			rows.set(kf.bone, track);
+		}
+		const marker = document.createElement("div");
+		marker.className = "kf-marker";
+		const t = kf.time - start;
+		marker.style.left = `${(t / duration) * 100}%`;
+		track.appendChild(marker);
+	}
+}
+
+function addKeyframe(bonePath = selectedBone): void {
+	const bone = getBone(bonePath);
 	keyframes.push({
 		time: Date.now(),
-		bone: selectedBone,
+		bone: bonePath,
 		position: bone.position.clone(),
 		rotation: bone.rotation.clone(),
 	});
-	const timeline = document.getElementById("timeline");
-	if (timeline) {
-		const entry = document.createElement("div");
-		entry.textContent = `Keyframe ${keyframes.length} (${selectedBone})`;
-		timeline.appendChild(entry);
+	updateTimeline();
+}
+
+function addIKKeyframe(chainName: string): void {
+	const chain = ikChains[chainName];
+	if (!chain) {
+		return;
 	}
+	const time = Date.now();
+	for (const bonePath of chain.bones) {
+		const bone = getBone(bonePath);
+		keyframes.push({
+			time,
+			bone: bonePath,
+			position: bone.position.clone(),
+			rotation: bone.rotation.clone(),
+		});
+	}
+	updateTimeline();
 }
 
 const boneSelector = document.getElementById("bone_selector") as HTMLSelectElement;
@@ -641,7 +761,20 @@ boneSelector?.addEventListener("change", () => {
 const toggleEditorBtn = document.getElementById("toggle_editor");
 toggleEditorBtn?.addEventListener("click", toggleEditor);
 const addKeyframeBtn = document.getElementById("add_keyframe");
-addKeyframeBtn?.addEventListener("click", addKeyframe);
+addKeyframeBtn?.addEventListener("click", () => {
+	if (selectedBone.startsWith("ik.")) {
+		addIKKeyframe(selectedBone);
+	} else {
+		addKeyframe();
+	}
+});
+
+const modeSelector = document.getElementById("transform_mode") as HTMLSelectElement;
+modeSelector?.addEventListener("change", () => {
+	if (transformControls) {
+		transformControls.setMode(modeSelector.value as any);
+	}
+});
 
 function buildKeyframeAnimation(): skinview3d.KeyframeAnimation | null {
 	if (keyframes.length === 0) {
@@ -692,8 +825,23 @@ async function uploadJson(e: Event): Promise<void> {
 		const data = JSON.parse(text);
 		loadedAnimation = skinview3d.createKeyframeAnimation(data);
 		skinViewer.animation = loadedAnimation;
+		keyframes.length = 0;
+		if (Array.isArray(data.keyframes)) {
+			for (const frame of data.keyframes) {
+				for (const [bone, rot] of Object.entries(frame.bones ?? {})) {
+					keyframes.push({
+						time: frame.time * 1000,
+						bone,
+						position: new Vector3(),
+						rotation: new Euler().fromArray(rot as [number, number, number]),
+					});
+				}
+			}
+			keyframes.sort((a, b) => a.time - b.time);
+			updateTimeline();
+		}
 		if (uploadStatusEl) {
-			uploadStatusEl.textContent = "Animation loaded.";
+			uploadStatusEl.textContent = `Loaded: ${file.name}`;
 			uploadStatusEl.classList.remove("hidden");
 		}
 	} catch (err) {

--- a/examples/style.css
+++ b/examples/style.css
@@ -95,3 +95,38 @@ label {
 .hidden {
 	display: none;
 }
+
+#timeline {
+	border: 1px solid #ccc;
+	margin: 10px 0;
+	padding: 4px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.kf-row {
+	display: flex;
+	align-items: center;
+	height: 20px;
+}
+
+.kf-label {
+	width: 120px;
+	font-size: 12px;
+}
+
+.kf-track {
+	position: relative;
+	flex: 1;
+	height: 100%;
+	background: #222;
+}
+
+.kf-marker {
+	position: absolute;
+	top: 0;
+	width: 2px;
+	height: 100%;
+	background: #f00;
+}


### PR DESCRIPTION
## Summary
- integrate Three.js CCDIKSolver for arm IK with selectable targets in the animation editor
- display keyframes on a per-bone timeline to mimic Blender's dope sheet
- document IK usage and timeline guidelines in AGENTS instructions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894065e1640832788d5e849e8a76bfc