### PR TITLE
examples: add leg IK chains and update instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,4 +42,5 @@ Following these practices will keep the project healthy, extensible, and bug-fre
 - The animation editor exposes elbow and knee joints; do not remove these options.
 - When improvements or bug fixes are made, document the lessons learned here so they aren't repeated.
 - CCDIKSolver integration relies on existing body part groups as bones. Ensure IK targets are included in the bone selector and keyframes capture all bones in a chain.
+- Arm and leg IK chains must be maintained and exposed in the bone selector to avoid regressions.
 - The timeline viewer displays keyframes per bone row. Avoid reverting to a single-row timeline.

--- a/examples/index.html
+++ b/examples/index.html
@@ -106,6 +106,8 @@
 							<option value="skin.leftLegKnee">skin.leftLegKnee</option>
 							<option value="ik.rightArm">IK: Right Arm</option>
 							<option value="ik.leftArm">IK: Left Arm</option>
+							<option value="ik.rightLeg">IK: Right Leg</option>
+							<option value="ik.leftLeg">IK: Left Leg</option>
 						</select>
 					</label>
 					<label class="control">

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -240,6 +240,38 @@ function setupIK(): void {
 		bones: ["skin.leftArm", "skin.leftArmElbow", "skin.leftArmLower"],
 	};
 
+	const rLegTarget = new Object3D();
+	rLegTarget.position.copy(skin.rightLegLower.getWorldPosition(new Vector3()));
+	skinViewer.scene.add(rLegTarget);
+	const rLegBones = [skin.rightLeg, skin.rightLegKnee, skin.rightLegLower, rLegTarget];
+	const rLegSkeleton = new Skeleton(rLegBones as any);
+	const rLegMesh = new SkinnedMesh(new BufferGeometry(), new MeshBasicMaterial());
+	rLegMesh.bind(rLegSkeleton);
+	const rLegSolver = new CCDIKSolver(rLegMesh, [
+		{ target: 3, effector: 2, links: [{ index: 1 }, { index: 0 }], iteration: 10 },
+	]);
+	ikChains["ik.rightLeg"] = {
+		target: rLegTarget,
+		solver: rLegSolver,
+		bones: ["skin.rightLeg", "skin.rightLegKnee", "skin.rightLegLower"],
+	};
+
+	const lLegTarget = new Object3D();
+	lLegTarget.position.copy(skin.leftLegLower.getWorldPosition(new Vector3()));
+	skinViewer.scene.add(lLegTarget);
+	const lLegBones = [skin.leftLeg, skin.leftLegKnee, skin.leftLegLower, lLegTarget];
+	const lLegSkeleton = new Skeleton(lLegBones as any);
+	const lLegMesh = new SkinnedMesh(new BufferGeometry(), new MeshBasicMaterial());
+	lLegMesh.bind(lLegSkeleton);
+	const lLegSolver = new CCDIKSolver(lLegMesh, [
+		{ target: 3, effector: 2, links: [{ index: 1 }, { index: 0 }], iteration: 10 },
+	]);
+	ikChains["ik.leftLeg"] = {
+		target: lLegTarget,
+		solver: lLegSolver,
+		bones: ["skin.leftLeg", "skin.leftLegKnee", "skin.leftLegLower"],
+	};
+
 	if (ikUpdateId !== null) {
 		cancelAnimationFrame(ikUpdateId);
 	}


### PR DESCRIPTION
## Summary
- extend example IK setup with chains for right and left legs
- expose new leg IK targets in the bone selector UI
- document maintaining arm and leg IK chains in AGENTS instructions

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689413723ff48327abdefbf8f5be8c12