### PR TITLE
fix: remove duplicate modeSelector declaration

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -776,13 +776,6 @@ modeSelector?.addEventListener("change", () => {
 	}
 });
 
-const modeSelector = document.getElementById("transform_mode") as HTMLSelectElement;
-modeSelector?.addEventListener("change", () => {
-	if (transformControls) {
-		transformControls.setMode(modeSelector.value as any);
-	}
-});
-
 function buildKeyframeAnimation(): skinview3d.KeyframeAnimation | null {
 	if (keyframes.length === 0) {
 		return null;


### PR DESCRIPTION
## Summary
- remove extra `modeSelector` declaration in example script

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689413bb72bc8327a590beb3541662bf