### PR TITLE
Fix duplicate mode selector declaration

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -692,7 +692,6 @@ function toggleEditor(): void {
 				}
 			}
 		});
-		const modeSelector = document.getElementById("transform_mode") as HTMLSelectElement;
 		if (modeSelector) {
 			transformControls.setMode(modeSelector.value as any);
 		}


### PR DESCRIPTION
## Summary
- remove duplicate modeSelector declaration in example code

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894190e5a208327bc076cc7865f4c43