### PR TITLE
Switch examples to three-ik for limb IK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
 			"dependencies": {
 				"@types/three": "^0.156.0",
 				"skinview-utils": "^0.7.1",
-				"three": "^0.156.0"
+				"three": "^0.156.0",
+				"three-ik": "^0.1.0"
 			},
 			"devDependencies": {
 				"@rollup/plugin-node-resolve": "^15.0.2",
@@ -6168,6 +6169,15 @@
 			"integrity": "sha512-kP7H0FK9d/k6t/XvQ9FO6i+QrePoDcNhwl0I02+wmUJRNSLCUIDMcfObnzQvxb37/0Uc9TDT0T1HgsRRrO6SYQ==",
 			"license": "MIT"
 		},
+		"node_modules/three-ik": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/three-ik/-/three-ik-0.1.0.tgz",
+			"integrity": "sha512-GwYgVSegvRI9/i/YFKxnIT4bn9gN5GtrZbgRRhxvihUccxYfjryrt9Gys5Bqn+ljbM/uF4a8wZETxdLVNAT+fw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"three": "*"
+			}
+		},
 		"node_modules/through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -10862,6 +10872,12 @@
 			"version": "0.156.1",
 			"resolved": "https://registry.npmjs.org/three/-/three-0.156.1.tgz",
 			"integrity": "sha512-kP7H0FK9d/k6t/XvQ9FO6i+QrePoDcNhwl0I02+wmUJRNSLCUIDMcfObnzQvxb37/0Uc9TDT0T1HgsRRrO6SYQ=="
+		},
+		"three-ik": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/three-ik/-/three-ik-0.1.0.tgz",
+			"integrity": "sha512-GwYgVSegvRI9/i/YFKxnIT4bn9gN5GtrZbgRRhxvihUccxYfjryrt9Gys5Bqn+ljbM/uF4a8wZETxdLVNAT+fw==",
+			"requires": {}
 		},
 		"through": {
 			"version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
 	"dependencies": {
 		"@types/three": "^0.156.0",
 		"skinview-utils": "^0.7.1",
-		"three": "^0.156.0"
+		"three": "^0.156.0",
+		"three-ik": "^0.1.0"
 	},
 	"devDependencies": {
 		"@rollup/plugin-node-resolve": "^15.0.2",


### PR DESCRIPTION
## Summary
- add `three-ik` dependency
- replace CCDIKSolver usage with IK/IKChain/IKJoint
- build IK chains per limb using hand/foot bones and solve each frame

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689423104fa08327afc5f78a4425bd89