### PR TITLE
Expose elbow and knee joints

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -87,6 +87,11 @@
 			<button id="reset_all" type="button" class="control">Reset All</button>
 
 			<div class="control-section">
+				<h1>Debug</h1>
+				<label class="control"><input id="highlight_joints" type="checkbox" /> Highlight elbows/knees</label>
+			</div>
+
+			<div class="control-section">
 				<h1>Animation Editor</h1>
 				<button id="toggle_editor" type="button" class="control">Create Animation</button>
 				<div id="animation_editor" class="hidden">

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -3,7 +3,7 @@ import type { ModelType } from "skinview-utils";
 import type { BackEquipment } from "../src/model";
 import { TransformControls } from "three/examples/jsm/controls/TransformControls.js";
 import { IK, IKChain, IKJoint } from "three-ik";
-import { Euler, Object3D, Quaternion, Vector3 } from "three";
+import { Euler, Object3D, Quaternion, Vector3, BoxHelper } from "three";
 import "./style.css";
 import { GeneratedAnimation } from "./generated-animation";
 
@@ -32,6 +32,36 @@ let loadedAnimation: skinview3d.Animation | null = null;
 let uploadStatusEl: HTMLElement | null = null;
 const ikChains: Record<string, { target: Object3D; effector: Object3D; ik: IK; bones: string[] }> = {};
 let ikUpdateId: number | null = null;
+let jointHelpers: BoxHelper[] = [];
+
+function updateJointHighlight(enabled: boolean): void {
+	for (const helper of jointHelpers) {
+		skinViewer.scene.remove(helper);
+	}
+	jointHelpers = [];
+	if (enabled) {
+		const joints = [
+			skinViewer.playerObject.skin.rightArmJoint,
+			skinViewer.playerObject.skin.leftArmJoint,
+			skinViewer.playerObject.skin.rightLegJoint,
+			skinViewer.playerObject.skin.leftLegJoint,
+		];
+		for (const joint of joints) {
+			const helper = new BoxHelper(joint, 0xff0000);
+			helper.update();
+			jointHelpers.push(helper);
+			skinViewer.scene.add(helper);
+		}
+	}
+}
+
+function updateJointHelpers(): void {
+	for (const helper of jointHelpers) {
+		helper.update();
+	}
+	requestAnimationFrame(updateJointHelpers);
+}
+updateJointHelpers();
 
 function getBone(path: string): Object3D {
 	if (path === "playerObject") {
@@ -216,7 +246,7 @@ function setupIK(): void {
 	for (const key in ikChains) {
 		delete ikChains[key];
 	}
-	const skin: any = skinViewer.playerObject.skin;
+	const skin = skinViewer.playerObject.skin;
 
 	const rightHandTarget = new Object3D();
 	rightHandTarget.position.copy(skin.rightArmHand.getWorldPosition(new Vector3()));
@@ -330,6 +360,7 @@ function initializeControls(): void {
 	const cameraLight = document.getElementById("camera_light") as HTMLInputElement;
 	const animationPauseResume = document.getElementById("animation_pause_resume");
 	const editorPlayPause = document.getElementById("editor_play_pause");
+	const highlightJoints = document.getElementById("highlight_joints") as HTMLInputElement;
 	const autoRotate = document.getElementById("auto_rotate") as HTMLInputElement;
 	const autoRotateSpeed = document.getElementById("auto_rotate_speed") as HTMLInputElement;
 	const controlRotate = document.getElementById("control_rotate") as HTMLInputElement;
@@ -388,6 +419,11 @@ function initializeControls(): void {
 	autoRotate?.addEventListener("change", e => {
 		const target = e.target as HTMLInputElement;
 		skinViewer.autoRotate = target.checked;
+	});
+
+	highlightJoints?.addEventListener("change", e => {
+		const target = e.target as HTMLInputElement;
+		updateJointHighlight(target.checked);
 	});
 
 	autoRotateSpeed?.addEventListener("change", e => {
@@ -667,6 +703,8 @@ function initializeViewer(): void {
 	reloadEars(true);
 	reloadPanorama();
 	reloadNameTag();
+	const highlightJoints = document.getElementById("highlight_joints") as HTMLInputElement;
+	updateJointHighlight(highlightJoints?.checked ?? false);
 }
 
 initializeViewer();

--- a/src/model.ts
+++ b/src/model.ts
@@ -80,6 +80,14 @@ export class BodyPart extends Group {
 	}
 }
 
+/**
+ * Represents a Minecraft player skin with individually accessible body parts
+ * and joints. Elbows, knees and their lower limbs are exposed for animation
+ * or inverse kinematics through the following groups:
+ * - `rightArmElbow`, `leftArmElbow`, `rightLegKnee`, `leftLegKnee`
+ * - `rightArmJoint`, `leftArmJoint`, `rightLegJoint`, `leftLegJoint`
+ * - `rightArmLower`, `leftArmLower`, `rightLegLower`, `leftLegLower`
+ */
 export class SkinObject extends Group {
 	// body parts
 	readonly head: BodyPart;
@@ -97,14 +105,14 @@ export class SkinObject extends Group {
 	readonly rightLegKnee: Group;
 	readonly leftLegKnee: Group;
 
-	private rightArmLower: BodyPart;
-	private leftArmLower: BodyPart;
-	private rightLegLower: BodyPart;
-	private leftLegLower: BodyPart;
-	private rightArmJoint: BodyPart;
-	private leftArmJoint: BodyPart;
-	private rightLegJoint: BodyPart;
-	private leftLegJoint: BodyPart;
+	readonly rightArmLower: BodyPart;
+	readonly leftArmLower: BodyPart;
+	readonly rightLegLower: BodyPart;
+	readonly leftLegLower: BodyPart;
+	readonly rightArmJoint: BodyPart;
+	readonly leftArmJoint: BodyPart;
+	readonly rightLegJoint: BodyPart;
+	readonly leftLegJoint: BodyPart;
 
 	private modelListeners: Array<() => void> = []; // called when model(slim property) is changed
 	private slim = false;
@@ -190,6 +198,7 @@ export class SkinObject extends Group {
 		rightUpperArm2Mesh.position.y = -3;
 
 		this.rightArmElbow = new Group();
+		this.rightArmElbow.name = "rightArmElbow";
 		this.rightArmElbow.position.y = -7;
 
 		const rightElbowBox = new BoxGeometry();
@@ -213,6 +222,7 @@ export class SkinObject extends Group {
 		rightElbow2Mesh.position.y = 0;
 
 		this.rightArmJoint = new BodyPart(rightElbowMesh, rightElbow2Mesh);
+		this.rightArmJoint.name = "rightArmJoint";
 		this.rightArmJoint.add(rightElbowMesh, rightElbow2Mesh);
 		this.rightArmElbow.add(this.rightArmJoint);
 
@@ -237,6 +247,7 @@ export class SkinObject extends Group {
 		rightLowerArm2Mesh.position.y = -3;
 
 		this.rightArmLower = new BodyPart(rightLowerArmMesh, rightLowerArm2Mesh);
+		this.rightArmLower.name = "rightArmLower";
 		this.rightArmLower.position.y = -1;
 		this.rightArmLower.add(rightLowerArmMesh, rightLowerArm2Mesh);
 		this.rightHand = new BodyPart(new Group(), new Group());
@@ -281,6 +292,7 @@ export class SkinObject extends Group {
 		leftUpperArm2Mesh.position.y = -3;
 
 		this.leftArmElbow = new Group();
+		this.leftArmElbow.name = "leftArmElbow";
 		this.leftArmElbow.position.y = -7;
 
 		const leftElbowBox = new BoxGeometry();
@@ -304,6 +316,7 @@ export class SkinObject extends Group {
 		leftElbow2Mesh.position.y = 0;
 
 		this.leftArmJoint = new BodyPart(leftElbowMesh, leftElbow2Mesh);
+		this.leftArmJoint.name = "leftArmJoint";
 		this.leftArmJoint.add(leftElbowMesh, leftElbow2Mesh);
 		this.leftArmElbow.add(this.leftArmJoint);
 
@@ -328,6 +341,7 @@ export class SkinObject extends Group {
 		leftLowerArm2Mesh.position.y = -3;
 
 		this.leftArmLower = new BodyPart(leftLowerArmMesh, leftLowerArm2Mesh);
+		this.leftArmLower.name = "leftArmLower";
 		this.leftArmLower.position.y = -1;
 		this.leftArmLower.add(leftLowerArmMesh, leftLowerArm2Mesh);
 		this.leftHand = new BodyPart(new Group(), new Group());
@@ -364,6 +378,7 @@ export class SkinObject extends Group {
 		rightUpperLeg2Mesh.position.y = -3;
 
 		this.rightLegKnee = new Group();
+		this.rightLegKnee.name = "rightLegKnee";
 		this.rightLegKnee.position.y = -7;
 
 		const rightKneeBox = new BoxGeometry();
@@ -379,6 +394,7 @@ export class SkinObject extends Group {
 		rightKnee2Mesh.position.y = 0;
 
 		this.rightLegJoint = new BodyPart(rightKneeMesh, rightKnee2Mesh);
+		this.rightLegJoint.name = "rightLegJoint";
 		this.rightLegJoint.add(rightKneeMesh, rightKnee2Mesh);
 		this.rightLegKnee.add(this.rightLegJoint);
 
@@ -395,6 +411,7 @@ export class SkinObject extends Group {
 		rightLowerLeg2Mesh.position.y = -3;
 
 		this.rightLegLower = new BodyPart(rightLowerLegMesh, rightLowerLeg2Mesh);
+		this.rightLegLower.name = "rightLegLower";
 		this.rightLegLower.position.y = -1;
 		this.rightLegLower.add(rightLowerLegMesh, rightLowerLeg2Mesh);
 		this.rightFoot = new BodyPart(new Group(), new Group());
@@ -425,6 +442,7 @@ export class SkinObject extends Group {
 		leftUpperLeg2Mesh.position.y = -3;
 
 		this.leftLegKnee = new Group();
+		this.leftLegKnee.name = "leftLegKnee";
 		this.leftLegKnee.position.y = -7;
 
 		const leftKneeBox = new BoxGeometry();
@@ -440,6 +458,7 @@ export class SkinObject extends Group {
 		leftKnee2Mesh.position.y = 0;
 
 		this.leftLegJoint = new BodyPart(leftKneeMesh, leftKnee2Mesh);
+		this.leftLegJoint.name = "leftLegJoint";
 		this.leftLegJoint.add(leftKneeMesh, leftKnee2Mesh);
 		this.leftLegKnee.add(this.leftLegJoint);
 
@@ -456,6 +475,7 @@ export class SkinObject extends Group {
 		leftLowerLeg2Mesh.position.y = -3;
 
 		this.leftLegLower = new BodyPart(leftLowerLegMesh, leftLowerLeg2Mesh);
+		this.leftLegLower.name = "leftLegLower";
 		this.leftLegLower.position.y = -1;
 		this.leftLegLower.add(leftLowerLegMesh, leftLowerLeg2Mesh);
 		this.leftFoot = new BodyPart(new Group(), new Group());


### PR DESCRIPTION
## Summary
- expose elbow and knee joints and lower limbs via public fields on `SkinObject`
- document and name newly exposed joints
- add demo toggle to highlight elbow/knee joints and update examples to use new API

## Testing
- `npm test`
- `npm run build` *(fails: "Math" is not exported by three.module.js, imported by three-ik.module.js)*

------
https://chatgpt.com/codex/tasks/task_e_6894c8a811f483278fc77aaea8e0988e