### PR TITLE
Add IK controller handle meshes

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -90,6 +90,7 @@
 				<h1>Animation Editor</h1>
 				<button id="toggle_editor" type="button" class="control">Create Animation</button>
 				<div id="animation_editor" class="hidden">
+					<p class="control">Select an IK controller and drag its colored sphere in the viewer to pose the limb.</p>
 					<label class="control">
 						Bone:
 						<select id="bone_selector">

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -3,7 +3,7 @@ import type { ModelType } from "skinview-utils";
 import type { BackEquipment } from "../src/model";
 import { TransformControls } from "three/examples/jsm/controls/TransformControls.js";
 import { IK, IKChain, IKJoint } from "three-ik";
-import { Euler, Object3D, Quaternion, Vector3 } from "three";
+import { Euler, Mesh, MeshBasicMaterial, Object3D, Quaternion, SphereGeometry, Vector3 } from "three";
 import "./style.css";
 import { GeneratedAnimation } from "./generated-animation";
 
@@ -211,14 +211,16 @@ function reloadNameTag(): void {
 function setupIK(): void {
 	for (const chain of Object.values(ikChains)) {
 		skinViewer.scene.remove(chain.target);
-		skinViewer.scene.remove(chain.effector);
+		if (chain.effector !== chain.target) {
+			skinViewer.scene.remove(chain.effector);
+		}
 	}
 	for (const key in ikChains) {
 		delete ikChains[key];
 	}
 	const skin: any = skinViewer.playerObject.skin;
 
-	const rightHandTarget = new Object3D();
+	const rightHandTarget = new Mesh(new SphereGeometry(2), new MeshBasicMaterial({ color: 0xff0000 }));
 	rightHandTarget.position.copy(skin.rightArmHand.getWorldPosition(new Vector3()));
 	skinViewer.scene.add(rightHandTarget);
 	const rIK = new IK();
@@ -231,11 +233,12 @@ function setupIK(): void {
 	rIK.add(rChain);
 	ikChains["ik.rightArm"] = {
 		target: rightHandTarget,
+		effector: rightHandTarget,
 		ik: rIK,
 		bones: ["skin.rightArm", "skin.rightArmElbow", "skin.rightArmLower", "skin.rightArmHand"],
 	};
 
-	const leftHandTarget = new Object3D();
+	const leftHandTarget = new Mesh(new SphereGeometry(2), new MeshBasicMaterial({ color: 0x0000ff }));
 	leftHandTarget.position.copy(skin.leftArmHand.getWorldPosition(new Vector3()));
 	skinViewer.scene.add(leftHandTarget);
 	const lIK = new IK();
@@ -248,11 +251,12 @@ function setupIK(): void {
 	lIK.add(lChain);
 	ikChains["ik.leftArm"] = {
 		target: leftHandTarget,
+		effector: leftHandTarget,
 		ik: lIK,
 		bones: ["skin.leftArm", "skin.leftArmElbow", "skin.leftArmLower", "skin.leftArmHand"],
 	};
 
-	const rightFootTarget = new Object3D();
+	const rightFootTarget = new Mesh(new SphereGeometry(2), new MeshBasicMaterial({ color: 0x00ff00 }));
 	rightFootTarget.position.copy(skin.rightLegFoot.getWorldPosition(new Vector3()));
 	skinViewer.scene.add(rightFootTarget);
 	const rLegIK = new IK();
@@ -265,11 +269,12 @@ function setupIK(): void {
 	rLegIK.add(rLegChain);
 	ikChains["ik.rightLeg"] = {
 		target: rightFootTarget,
+		effector: rightFootTarget,
 		ik: rLegIK,
 		bones: ["skin.rightLeg", "skin.rightLegKnee", "skin.rightLegLower", "skin.rightLegFoot"],
 	};
 
-	const leftFootTarget = new Object3D();
+	const leftFootTarget = new Mesh(new SphereGeometry(2), new MeshBasicMaterial({ color: 0xffff00 }));
 	leftFootTarget.position.copy(skin.leftLegFoot.getWorldPosition(new Vector3()));
 	skinViewer.scene.add(leftFootTarget);
 	const lLegIK = new IK();
@@ -282,6 +287,7 @@ function setupIK(): void {
 	lLegIK.add(lLegChain);
 	ikChains["ik.leftLeg"] = {
 		target: leftFootTarget,
+		effector: leftFootTarget,
 		ik: lLegIK,
 		bones: ["skin.leftLeg", "skin.leftLegKnee", "skin.leftLegLower", "skin.leftLegFoot"],
 	};
@@ -312,7 +318,9 @@ function disposeIK(): void {
 	}
 	for (const chain of Object.values(ikChains)) {
 		skinViewer.scene.remove(chain.target);
-		skinViewer.scene.remove(chain.effector);
+		if (chain.effector !== chain.target) {
+			skinViewer.scene.remove(chain.effector);
+		}
 	}
 	for (const key in ikChains) {
 		delete ikChains[key];
@@ -699,7 +707,9 @@ function initializeBoneSelector(useIK = false): void {
 	for (const key of Object.keys(ikChains)) {
 		const option = document.createElement("option");
 		option.value = key;
-		option.textContent = key;
+		const part = key.replace(/^ik\./, "");
+		const label = part.replace(/([A-Z])/g, " $1").replace(/^./, c => c.toUpperCase());
+		option.textContent = `IK Controller: ${label}`;
 		selector.appendChild(option);
 	}
 

--- a/examples/three-shim.ts
+++ b/examples/three-shim.ts
@@ -1,0 +1,3 @@
+export * from "three/src/Three.js";
+export { MathUtils as Math } from "three/src/math/MathUtils.js";
+export { ConeGeometry as ConeBufferGeometry } from "three/src/geometries/ConeGeometry.js";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,23 @@
 import { defineConfig } from "vite";
+import { resolve } from "path";
 
 export default defineConfig({
-	base: "./",
-	root: "examples",
-	build: {
-		rollupOptions: {
-			input: {
-				main: "./examples/index.html",
-				offscreen: "./examples/offscreen-render.html",
-			},
-		},
-	},
+        base: "./",
+        root: "examples",
+        resolve: {
+                alias: [
+                        {
+                                find: /^three$/,
+                                replacement: resolve(__dirname, "examples/three-shim.ts"),
+                        },
+                ],
+        },
+        build: {
+                rollupOptions: {
+                        input: {
+                                main: "./examples/index.html",
+                                offscreen: "./examples/offscreen-render.html",
+                        },
+                },
+        },
 });


### PR DESCRIPTION
## Summary
- Add visible sphere meshes as IK controller targets for arms and legs
- Expose these controllers in bone selector and document usage
- Shim three exports so three-ik builds with the preview

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894c8adb0988327a85020b3f39e6df7