### PR TITLE
Refactor limbs to use bones and skinned meshes

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -19,10 +19,10 @@ const skinParts = [
 	"leftArmElbow",
 	"rightLegKnee",
 	"leftLegKnee",
-	"rightArmLower",
-	"leftArmLower",
-	"rightLegLower",
-	"leftLegLower",
+	"rightArmWrist",
+	"leftArmWrist",
+	"rightLegAnkle",
+	"leftLegAnkle",
 	"rightHand",
 	"leftHand",
 	"rightFoot",
@@ -61,18 +61,14 @@ function updateJointHighlight(enabled: boolean): void {
 	jointHelpers = [];
 	if (enabled) {
 		const joints = [
-			skinViewer.playerObject.skin.rightArmJoint,
-			skinViewer.playerObject.skin.leftArmJoint,
-			skinViewer.playerObject.skin.rightLegJoint,
-			skinViewer.playerObject.skin.leftLegJoint,
 			skinViewer.playerObject.skin.rightArmElbow,
 			skinViewer.playerObject.skin.leftArmElbow,
+			skinViewer.playerObject.skin.rightArmWrist,
+			skinViewer.playerObject.skin.leftArmWrist,
 			skinViewer.playerObject.skin.rightLegKnee,
 			skinViewer.playerObject.skin.leftLegKnee,
-			skinViewer.playerObject.skin.rightArmLower,
-			skinViewer.playerObject.skin.leftArmLower,
-			skinViewer.playerObject.skin.rightLegLower,
-			skinViewer.playerObject.skin.leftLegLower,
+			skinViewer.playerObject.skin.rightLegAnkle,
+			skinViewer.playerObject.skin.leftLegAnkle,
 			skinViewer.playerObject.skin.rightHand,
 			skinViewer.playerObject.skin.leftHand,
 			skinViewer.playerObject.skin.rightFoot,
@@ -306,14 +302,14 @@ function setupIK(): void {
 	const rRoot = new IKJoint(skin.rightArm, { constraints: [createLockConstraint()] });
 	rChain.add(rRoot); // keep shoulder static
 	rChain.add(new IKJoint(skin.rightArmElbow));
-	rChain.add(new IKJoint(skin.rightArmLower));
+	rChain.add(new IKJoint(skin.rightArmWrist));
 	rChain.add(new IKJoint(skin.rightHand), { target: rightHandTarget });
 	rChain.effectorIndex = rChain.joints.length - 1;
 	rIK.add(rChain);
 	ikChains["ik.rightArm"] = {
 		target: rightHandTarget,
 		ik: rIK,
-		bones: ["skin.rightArm", "skin.rightArmElbow", "skin.rightArmLower", "skin.rightHand"],
+		bones: ["skin.rightArm", "skin.rightArmElbow", "skin.rightArmWrist", "skin.rightHand"],
 		root: rRoot,
 	};
 
@@ -328,7 +324,7 @@ function setupIK(): void {
 	const lRoot = new IKJoint(skin.leftArm, { constraints: [createLockConstraint()] });
 	lChain.add(lRoot); // keep shoulder static
 	lChain.add(new IKJoint(skin.leftArmElbow));
-	lChain.add(new IKJoint(skin.leftArmLower));
+	lChain.add(new IKJoint(skin.leftArmWrist));
 	lChain.add(new IKJoint(skin.leftHand), { target: leftHandTarget });
 	lChain.effectorIndex = lChain.joints.length - 1;
 	lIK.add(lChain);
@@ -336,7 +332,7 @@ function setupIK(): void {
 		target: leftHandTarget,
 
 		ik: lIK,
-		bones: ["skin.leftArm", "skin.leftArmElbow", "skin.leftArmLower", "skin.leftHand"],
+		bones: ["skin.leftArm", "skin.leftArmElbow", "skin.leftArmWrist", "skin.leftHand"],
 		root: lRoot,
 	};
 
@@ -344,22 +340,22 @@ function setupIK(): void {
 	const rightFootMesh = new Mesh(new SphereGeometry(0.5), new MeshBasicMaterial({ color: 0x0000ff }));
 	rightFootTarget.add(rightFootMesh);
 
-	rightFootTarget.position.copy(skin.rightLegFoot.getWorldPosition(new Vector3()));
+	rightFootTarget.position.copy(skin.rightFoot.getWorldPosition(new Vector3()));
 	skinViewer.scene.add(rightFootTarget);
 	const rLegIK = new IK();
 	const rLegChain = new IKChain();
 	const rLegRoot = new IKJoint(skin.rightLeg, { constraints: [createLockConstraint()] });
 	rLegChain.add(rLegRoot); // keep hip static
 	rLegChain.add(new IKJoint(skin.rightLegKnee));
-	rLegChain.add(new IKJoint(skin.rightLegLower));
-	rLegChain.add(new IKJoint(skin.rightLegFoot), { target: rightFootTarget });
+	rLegChain.add(new IKJoint(skin.rightLegAnkle));
+	rLegChain.add(new IKJoint(skin.rightFoot), { target: rightFootTarget });
 	rLegChain.effectorIndex = rLegChain.joints.length - 1;
 	rLegIK.add(rLegChain);
 	ikChains["ik.rightLeg"] = {
 		target: rightFootTarget,
 
 		ik: rLegIK,
-		bones: ["skin.rightLeg", "skin.rightLegKnee", "skin.rightLegLower", "skin.rightLegFoot"],
+		bones: ["skin.rightLeg", "skin.rightLegKnee", "skin.rightLegAnkle", "skin.rightFoot"],
 		root: rLegRoot,
 	};
 
@@ -367,21 +363,21 @@ function setupIK(): void {
 	const leftFootMesh = new Mesh(new SphereGeometry(0.5), new MeshBasicMaterial({ color: 0xffff00 }));
 	leftFootTarget.add(leftFootMesh);
 
-	leftFootTarget.position.copy(skin.leftLegFoot.getWorldPosition(new Vector3()));
+	leftFootTarget.position.copy(skin.leftFoot.getWorldPosition(new Vector3()));
 	skinViewer.scene.add(leftFootTarget);
 	const lLegIK = new IK();
 	const lLegChain = new IKChain();
 	const lLegRoot = new IKJoint(skin.leftLeg, { constraints: [createLockConstraint()] });
 	lLegChain.add(lLegRoot); // keep hip static
 	lLegChain.add(new IKJoint(skin.leftLegKnee));
-	lLegChain.add(new IKJoint(skin.leftLegLower));
-	lLegChain.add(new IKJoint(skin.leftLegFoot), { target: leftFootTarget });
+	lLegChain.add(new IKJoint(skin.leftLegAnkle));
+	lLegChain.add(new IKJoint(skin.leftFoot), { target: leftFootTarget });
 	lLegChain.effectorIndex = lLegChain.joints.length - 1;
 	lLegIK.add(lLegChain);
 	ikChains["ik.leftLeg"] = {
 		target: leftFootTarget,
 		ik: lLegIK,
-		bones: ["skin.leftLeg", "skin.leftLegKnee", "skin.leftLegLower", "skin.leftLegFoot"],
+		bones: ["skin.leftLeg", "skin.leftLegKnee", "skin.leftLegAnkle", "skin.leftFoot"],
 		root: lLegRoot,
 	};
 

--- a/src/animation.ts
+++ b/src/animation.ts
@@ -495,24 +495,32 @@ export class BendAnimation extends PlayerAnimation {
 		const arm = s * this.armBend;
 		const leg = s * this.legBend;
 
-		// Bend arms around the shoulder and elbow joints for a smoother curve
+		// Bend arms across shoulder, elbow and wrist bones
 		const armUpper = 5;
 		const armLower = 5;
 		const armShoulderRatio = armLower / (armUpper + armLower);
 		const armElbowRatio = armUpper / (armUpper + armLower);
 		player.skin.leftArm.rotation.x = arm * armShoulderRatio;
-		player.skin.leftArmElbow.rotation.x = arm * armElbowRatio;
 		player.skin.rightArm.rotation.x = arm * armShoulderRatio;
-		player.skin.rightArmElbow.rotation.x = arm * armElbowRatio;
+		const elbow = arm * armElbowRatio * 0.6;
+		const wrist = arm * armElbowRatio * 0.4;
+		player.skin.leftArmElbow.rotation.x = elbow;
+		player.skin.leftArmWrist.rotation.x = wrist;
+		player.skin.rightArmElbow.rotation.x = elbow;
+		player.skin.rightArmWrist.rotation.x = wrist;
 
-		// Bend legs around the hip and knee joints
+		// Bend legs across hip, knee and ankle bones
 		const legUpper = 5;
 		const legLower = 5;
 		const legHipRatio = legLower / (legUpper + legLower);
 		const legKneeRatio = legUpper / (legUpper + legLower);
 		player.skin.leftLeg.rotation.x = -leg * legHipRatio;
-		player.skin.leftLegKnee.rotation.x = -leg * legKneeRatio;
 		player.skin.rightLeg.rotation.x = -leg * legHipRatio;
-		player.skin.rightLegKnee.rotation.x = -leg * legKneeRatio;
+		const knee = -leg * legKneeRatio * 0.6;
+		const ankle = -leg * legKneeRatio * 0.4;
+		player.skin.leftLegKnee.rotation.x = knee;
+		player.skin.leftLegAnkle.rotation.x = ankle;
+		player.skin.rightLegKnee.rotation.x = knee;
+		player.skin.rightLegAnkle.rotation.x = ankle;
 	}
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,9 +2,13 @@ import type { ModelType } from "skinview-utils";
 import {
 	BoxGeometry,
 	BufferAttribute,
+	Uint16BufferAttribute,
 	DoubleSide,
 	FrontSide,
 	Group,
+	Bone,
+	Skeleton,
+	SkinnedMesh,
 	Mesh,
 	MeshStandardMaterial,
 	Object3D,
@@ -66,6 +70,27 @@ function setCapeUVs(box: BoxGeometry, u: number, v: number, width: number, heigh
 	setUVs(box, u, v, width, height, depth, 64, 32);
 }
 
+function applyLimbSkinning(box: BoxGeometry): void {
+	const pos = box.attributes.position as BufferAttribute;
+	const vertexCount = pos.count;
+	const skinIndices: number[] = [];
+	const skinWeights: number[] = [];
+	for (let i = 0; i < vertexCount; i++) {
+		const y = pos.getY(i);
+		if (y >= -6) {
+			const s = -y / 6;
+			skinIndices.push(0, 1, 0, 0);
+			skinWeights.push(1 - s, s, 0, 0);
+		} else {
+			const s = (-y - 6) / 6;
+			skinIndices.push(1, 2, 0, 0);
+			skinWeights.push(1 - s, s, 0, 0);
+		}
+	}
+	box.setAttribute("skinIndex", new Uint16BufferAttribute(skinIndices, 4));
+	box.setAttribute("skinWeight", new BufferAttribute(new Float32Array(skinWeights), 4));
+}
+
 /**
  * Notice that innerLayer and outerLayer may NOT be the direct children of the Group.
  */
@@ -83,10 +108,9 @@ export class BodyPart extends Group {
 /**
  * Represents a Minecraft player skin with individually accessible body parts
  * and joints. Elbows, knees and their lower limbs are exposed for animation
- * or inverse kinematics through the following groups:
+ * or inverse kinematics through the following bones:
  * - `rightArmElbow`, `leftArmElbow`, `rightLegKnee`, `leftLegKnee`
- * - `rightArmJoint`, `leftArmJoint`, `rightLegJoint`, `leftLegJoint`
- * - `rightArmLower`, `leftArmLower`, `rightLegLower`, `leftLegLower`
+ * - `rightArmWrist`, `leftArmWrist`, `rightLegAnkle`, `leftLegAnkle`
  */
 export class SkinObject extends Group {
 	// body parts
@@ -100,19 +124,14 @@ export class SkinObject extends Group {
 	readonly leftHand: BodyPart;
 	readonly rightFoot: BodyPart;
 	readonly leftFoot: BodyPart;
-	readonly rightArmElbow: Group;
-	readonly leftArmElbow: Group;
-	readonly rightLegKnee: Group;
-	readonly leftLegKnee: Group;
-
-	readonly rightArmLower: BodyPart;
-	readonly leftArmLower: BodyPart;
-	readonly rightLegLower: BodyPart;
-	readonly leftLegLower: BodyPart;
-	readonly rightArmJoint: BodyPart;
-	readonly leftArmJoint: BodyPart;
-	readonly rightLegJoint: BodyPart;
-	readonly leftLegJoint: BodyPart;
+	readonly rightArmElbow: Bone;
+	readonly leftArmElbow: Bone;
+	readonly rightArmWrist: Bone;
+	readonly leftArmWrist: Bone;
+	readonly rightLegKnee: Bone;
+	readonly leftLegKnee: Bone;
+	readonly rightLegAnkle: Bone;
+	readonly leftLegAnkle: Bone;
 
 	private modelListeners: Array<() => void> = []; // called when model(slim property) is changed
 	private slim = false;
@@ -177,356 +196,218 @@ export class SkinObject extends Group {
 		this.add(this.body);
 
 		// Right Arm
-		const rightUpperArmBox = new BoxGeometry();
-		const rightUpperArmMesh = new Mesh(rightUpperArmBox, this.layer1MaterialBiased);
+		const rightArmBox = new BoxGeometry(1, 12, 1, 1, 12, 1);
+		rightArmBox.translate(0, -6, 0);
+		applyLimbSkinning(rightArmBox);
+		const rightArmMesh = new SkinnedMesh(rightArmBox, this.layer1MaterialBiased);
 		this.modelListeners.push(() => {
-			rightUpperArmMesh.scale.x = this.slim ? 3 : 4;
-			rightUpperArmMesh.scale.y = 5;
-			rightUpperArmMesh.scale.z = 4;
-			setSkinUVs(rightUpperArmBox, 40, 16, this.slim ? 3 : 4, 5, 4);
+			rightArmMesh.scale.set(this.slim ? 3 : 4, 1, 4);
+			setSkinUVs(rightArmBox, 40, 16, this.slim ? 3 : 4, 12, 4);
+			rightArmMesh.position.x = this.slim ? -0.5 : -1;
 		});
-		rightUpperArmMesh.position.y = -2.5;
+		setSkinUVs(rightArmBox, 40, 16, this.slim ? 3 : 4, 12, 4);
 
-		const rightUpperArm2Box = new BoxGeometry();
-		const rightUpperArm2Mesh = new Mesh(rightUpperArm2Box, this.layer2MaterialBiased);
+		const rightArm2Box = new BoxGeometry(1, 12, 1, 1, 12, 1);
+		rightArm2Box.translate(0, -6, 0);
+		applyLimbSkinning(rightArm2Box);
+		const rightArm2Mesh = new SkinnedMesh(rightArm2Box, this.layer2MaterialBiased);
 		this.modelListeners.push(() => {
-			rightUpperArm2Mesh.scale.x = this.slim ? 3.5 : 4.5;
-			rightUpperArm2Mesh.scale.y = 5.5;
-			rightUpperArm2Mesh.scale.z = 4.5;
-			setSkinUVs(rightUpperArm2Box, 40, 32, this.slim ? 3 : 4, 5, 4);
+			rightArm2Mesh.scale.set(this.slim ? 3.5 : 4.5, 1, 4.5);
+			setSkinUVs(rightArm2Box, 40, 32, this.slim ? 3 : 4, 12, 4);
+			rightArm2Mesh.position.x = this.slim ? -0.5 : -1;
 		});
-		rightUpperArm2Mesh.position.y = -2.5;
+		setSkinUVs(rightArm2Box, 40, 32, this.slim ? 3 : 4, 12, 4);
 
-		this.rightArmElbow = new Group();
-		this.rightArmElbow.name = "rightArmElbow";
-		this.rightArmElbow.position.y = -6;
+		const rightShoulder = new Bone();
+		const rightElbow = new Bone();
+		const rightWrist = new Bone();
+		rightElbow.position.y = -6;
+		rightWrist.position.y = -6;
+		rightShoulder.add(rightElbow);
+		rightElbow.add(rightWrist);
+		const rightArmSkeleton = new Skeleton([rightShoulder, rightElbow, rightWrist]);
+		rightArmMesh.add(rightShoulder);
+		rightArmMesh.bind(rightArmSkeleton);
+		rightArm2Mesh.bind(rightArmSkeleton);
 
-		const rightElbowBox = new BoxGeometry();
-		const rightElbowMesh = new Mesh(rightElbowBox, this.layer1MaterialBiased);
-		this.modelListeners.push(() => {
-			rightElbowMesh.scale.x = this.slim ? 3 : 4;
-			rightElbowMesh.scale.y = 2;
-			rightElbowMesh.scale.z = 4;
-			setSkinUVs(rightElbowBox, 40, 21, this.slim ? 3 : 4, 2, 4);
-		});
-		rightElbowMesh.position.y = 0;
+		this.rightArmElbow = rightElbow;
+		this.rightArmWrist = rightWrist;
 
-		const rightElbow2Box = new BoxGeometry();
-		const rightElbow2Mesh = new Mesh(rightElbow2Box, this.layer2MaterialBiased);
-		this.modelListeners.push(() => {
-			rightElbow2Mesh.scale.x = this.slim ? 3.5 : 4.5;
-			rightElbow2Mesh.scale.y = 2.5;
-			rightElbow2Mesh.scale.z = 4.5;
-			setSkinUVs(rightElbow2Box, 40, 37, this.slim ? 3 : 4, 2, 4);
-		});
-		rightElbow2Mesh.position.y = 0;
-
-		this.rightArmJoint = new BodyPart(rightElbowMesh, rightElbow2Mesh);
-		this.rightArmJoint.name = "rightArmJoint";
-		this.rightArmJoint.add(rightElbowMesh, rightElbow2Mesh);
-		this.rightArmElbow.add(this.rightArmJoint);
-
-		const rightLowerArmBox = new BoxGeometry();
-		const rightLowerArmMesh = new Mesh(rightLowerArmBox, this.layer1MaterialBiased);
-		this.modelListeners.push(() => {
-			rightLowerArmMesh.scale.x = this.slim ? 3 : 4;
-			rightLowerArmMesh.scale.y = 5;
-			rightLowerArmMesh.scale.z = 4;
-			setSkinUVs(rightLowerArmBox, 40, 23, this.slim ? 3 : 4, 5, 4);
-		});
-		rightLowerArmMesh.position.y = -2.5;
-
-		const rightLowerArm2Box = new BoxGeometry();
-		const rightLowerArm2Mesh = new Mesh(rightLowerArm2Box, this.layer2MaterialBiased);
-		this.modelListeners.push(() => {
-			rightLowerArm2Mesh.scale.x = this.slim ? 3.5 : 4.5;
-			rightLowerArm2Mesh.scale.y = 5.5;
-			rightLowerArm2Mesh.scale.z = 4.5;
-			setSkinUVs(rightLowerArm2Box, 40, 39, this.slim ? 3 : 4, 5, 4);
-		});
-		rightLowerArm2Mesh.position.y = -2.5;
-
-		this.rightArmLower = new BodyPart(rightLowerArmMesh, rightLowerArm2Mesh);
-		this.rightArmLower.name = "rightArmLower";
-		this.rightArmLower.position.y = -1;
-		this.rightArmLower.add(rightLowerArmMesh, rightLowerArm2Mesh);
 		const rightHandBox = new BoxGeometry(4, 4, 4);
 		setSkinUVs(rightHandBox, 40, 24, 4, 4, 4);
 		const rightHandMesh = new Mesh(rightHandBox, this.layer1MaterialBiased);
 		rightHandMesh.position.y = -2;
-
 		const rightHand2Box = new BoxGeometry(4.5, 4.5, 4.5);
 		setSkinUVs(rightHand2Box, 40, 40, 4, 4, 4);
 		const rightHand2Mesh = new Mesh(rightHand2Box, this.layer2MaterialBiased);
 		rightHand2Mesh.position.y = -2;
-
 		this.rightHand = new BodyPart(rightHandMesh, rightHand2Mesh);
 		this.rightHand.name = "rightHand";
-		this.rightHand.position.y = -5;
-		this.rightArmLower.add(this.rightHand);
-		this.rightArmElbow.add(this.rightArmLower);
+		this.rightArmWrist.add(this.rightHand);
 
-		const rightArmPivot = new Group();
-		rightArmPivot.add(rightUpperArmMesh, rightUpperArm2Mesh, this.rightArmElbow);
-		this.modelListeners.push(() => {
-			rightArmPivot.position.x = this.slim ? -0.5 : -1;
-		});
-		rightArmPivot.position.y = 2;
-
-		this.rightArm = new BodyPart(rightUpperArmMesh, rightUpperArm2Mesh);
+		this.rightArm = new BodyPart(rightArmMesh, rightArm2Mesh);
 		this.rightArm.name = "rightArm";
-		this.rightArm.add(rightArmPivot);
+		rightArmMesh.add(rightArm2Mesh);
+		this.rightArm.add(rightArmMesh);
 		this.rightArm.position.x = -5;
 		this.rightArm.position.y = -2;
 		this.add(this.rightArm);
 
 		// Left Arm
-		const leftUpperArmBox = new BoxGeometry();
-		const leftUpperArmMesh = new Mesh(leftUpperArmBox, this.layer1MaterialBiased);
+		const leftArmBox = new BoxGeometry(1, 12, 1, 1, 12, 1);
+		leftArmBox.translate(0, -6, 0);
+		applyLimbSkinning(leftArmBox);
+		const leftArmMesh = new SkinnedMesh(leftArmBox, this.layer1MaterialBiased);
 		this.modelListeners.push(() => {
-			leftUpperArmMesh.scale.x = this.slim ? 3 : 4;
-			leftUpperArmMesh.scale.y = 5;
-			leftUpperArmMesh.scale.z = 4;
-			setSkinUVs(leftUpperArmBox, 32, 48, this.slim ? 3 : 4, 5, 4);
+			leftArmMesh.scale.set(this.slim ? 3 : 4, 1, 4);
+			setSkinUVs(leftArmBox, 32, 48, this.slim ? 3 : 4, 12, 4);
+			leftArmMesh.position.x = this.slim ? 0.5 : 1;
 		});
-		leftUpperArmMesh.position.y = -2.5;
+		setSkinUVs(leftArmBox, 32, 48, this.slim ? 3 : 4, 12, 4);
 
-		const leftUpperArm2Box = new BoxGeometry();
-		const leftUpperArm2Mesh = new Mesh(leftUpperArm2Box, this.layer2MaterialBiased);
+		const leftArm2Box = new BoxGeometry(1, 12, 1, 1, 12, 1);
+		leftArm2Box.translate(0, -6, 0);
+		applyLimbSkinning(leftArm2Box);
+		const leftArm2Mesh = new SkinnedMesh(leftArm2Box, this.layer2MaterialBiased);
 		this.modelListeners.push(() => {
-			leftUpperArm2Mesh.scale.x = this.slim ? 3.5 : 4.5;
-			leftUpperArm2Mesh.scale.y = 5.5;
-			leftUpperArm2Mesh.scale.z = 4.5;
-			setSkinUVs(leftUpperArm2Box, 48, 48, this.slim ? 3 : 4, 5, 4);
+			leftArm2Mesh.scale.set(this.slim ? 3.5 : 4.5, 1, 4.5);
+			setSkinUVs(leftArm2Box, 48, 48, this.slim ? 3 : 4, 12, 4);
+			leftArm2Mesh.position.x = this.slim ? 0.5 : 1;
 		});
-		leftUpperArm2Mesh.position.y = -2.5;
+		setSkinUVs(leftArm2Box, 48, 48, this.slim ? 3 : 4, 12, 4);
 
-		this.leftArmElbow = new Group();
-		this.leftArmElbow.name = "leftArmElbow";
-		this.leftArmElbow.position.y = -6;
+		const leftShoulder = new Bone();
+		const leftElbow = new Bone();
+		const leftWrist = new Bone();
+		leftElbow.position.y = -6;
+		leftWrist.position.y = -6;
+		leftShoulder.add(leftElbow);
+		leftElbow.add(leftWrist);
+		const leftArmSkeleton = new Skeleton([leftShoulder, leftElbow, leftWrist]);
+		leftArmMesh.add(leftShoulder);
+		leftArmMesh.bind(leftArmSkeleton);
+		leftArm2Mesh.bind(leftArmSkeleton);
 
-		const leftElbowBox = new BoxGeometry();
-		const leftElbowMesh = new Mesh(leftElbowBox, this.layer1MaterialBiased);
-		this.modelListeners.push(() => {
-			leftElbowMesh.scale.x = this.slim ? 3 : 4;
-			leftElbowMesh.scale.y = 2;
-			leftElbowMesh.scale.z = 4;
-			setSkinUVs(leftElbowBox, 32, 53, this.slim ? 3 : 4, 2, 4);
-		});
-		leftElbowMesh.position.y = 0;
+		this.leftArmElbow = leftElbow;
+		this.leftArmWrist = leftWrist;
 
-		const leftElbow2Box = new BoxGeometry();
-		const leftElbow2Mesh = new Mesh(leftElbow2Box, this.layer2MaterialBiased);
-		this.modelListeners.push(() => {
-			leftElbow2Mesh.scale.x = this.slim ? 3.5 : 4.5;
-			leftElbow2Mesh.scale.y = 2.5;
-			leftElbow2Mesh.scale.z = 4.5;
-			setSkinUVs(leftElbow2Box, 48, 53, this.slim ? 3 : 4, 2, 4);
-		});
-		leftElbow2Mesh.position.y = 0;
-
-		this.leftArmJoint = new BodyPart(leftElbowMesh, leftElbow2Mesh);
-		this.leftArmJoint.name = "leftArmJoint";
-		this.leftArmJoint.add(leftElbowMesh, leftElbow2Mesh);
-		this.leftArmElbow.add(this.leftArmJoint);
-
-		const leftLowerArmBox = new BoxGeometry();
-		const leftLowerArmMesh = new Mesh(leftLowerArmBox, this.layer1MaterialBiased);
-		this.modelListeners.push(() => {
-			leftLowerArmMesh.scale.x = this.slim ? 3 : 4;
-			leftLowerArmMesh.scale.y = 5;
-			leftLowerArmMesh.scale.z = 4;
-			setSkinUVs(leftLowerArmBox, 32, 55, this.slim ? 3 : 4, 5, 4);
-		});
-		leftLowerArmMesh.position.y = -2.5;
-
-		const leftLowerArm2Box = new BoxGeometry();
-		const leftLowerArm2Mesh = new Mesh(leftLowerArm2Box, this.layer2MaterialBiased);
-		this.modelListeners.push(() => {
-			leftLowerArm2Mesh.scale.x = this.slim ? 3.5 : 4.5;
-			leftLowerArm2Mesh.scale.y = 5.5;
-			leftLowerArm2Mesh.scale.z = 4.5;
-			setSkinUVs(leftLowerArm2Box, 48, 55, this.slim ? 3 : 4, 5, 4);
-		});
-		leftLowerArm2Mesh.position.y = -2.5;
-
-		this.leftArmLower = new BodyPart(leftLowerArmMesh, leftLowerArm2Mesh);
-		this.leftArmLower.name = "leftArmLower";
-		this.leftArmLower.position.y = -1;
-		this.leftArmLower.add(leftLowerArmMesh, leftLowerArm2Mesh);
 		const leftHandBox = new BoxGeometry(4, 4, 4);
 		setSkinUVs(leftHandBox, 32, 56, 4, 4, 4);
 		const leftHandMesh = new Mesh(leftHandBox, this.layer1MaterialBiased);
 		leftHandMesh.position.y = -2;
-
 		const leftHand2Box = new BoxGeometry(4.5, 4.5, 4.5);
 		setSkinUVs(leftHand2Box, 48, 56, 4, 4, 4);
 		const leftHand2Mesh = new Mesh(leftHand2Box, this.layer2MaterialBiased);
 		leftHand2Mesh.position.y = -2;
-
 		this.leftHand = new BodyPart(leftHandMesh, leftHand2Mesh);
 		this.leftHand.name = "leftHand";
-		this.leftHand.position.y = -5;
-		this.leftArmLower.add(this.leftHand);
-		this.leftArmElbow.add(this.leftArmLower);
+		this.leftArmWrist.add(this.leftHand);
 
-		const leftArmPivot = new Group();
-		leftArmPivot.add(leftUpperArmMesh, leftUpperArm2Mesh, this.leftArmElbow);
-		this.modelListeners.push(() => {
-			leftArmPivot.position.x = this.slim ? 0.5 : 1;
-		});
-		leftArmPivot.position.y = 2;
-
-		this.leftArm = new BodyPart(leftUpperArmMesh, leftUpperArm2Mesh);
+		this.leftArm = new BodyPart(leftArmMesh, leftArm2Mesh);
 		this.leftArm.name = "leftArm";
-		this.leftArm.add(leftArmPivot);
+		leftArmMesh.add(leftArm2Mesh);
+		this.leftArm.add(leftArmMesh);
 		this.leftArm.position.x = 5;
 		this.leftArm.position.y = -2;
 		this.add(this.leftArm);
 
 		// Right Leg
-		const rightUpperLegBox = new BoxGeometry();
-		const rightUpperLegMesh = new Mesh(rightUpperLegBox, this.layer1MaterialBiased);
-		rightUpperLegMesh.scale.set(4, 5, 4);
-		setSkinUVs(rightUpperLegBox, 0, 16, 4, 5, 4);
-		rightUpperLegMesh.position.y = -2.5;
+		const rightLegBox = new BoxGeometry(1, 12, 1, 1, 12, 1);
+		rightLegBox.translate(0, -6, 0);
+		applyLimbSkinning(rightLegBox);
+		const rightLegMesh = new SkinnedMesh(rightLegBox, this.layer1MaterialBiased);
+		rightLegMesh.scale.set(4, 1, 4);
+		setSkinUVs(rightLegBox, 0, 16, 4, 12, 4);
 
-		const rightUpperLeg2Box = new BoxGeometry();
-		const rightUpperLeg2Mesh = new Mesh(rightUpperLeg2Box, this.layer2MaterialBiased);
-		rightUpperLeg2Mesh.scale.set(4.5, 5.5, 4.5);
-		setSkinUVs(rightUpperLeg2Box, 0, 32, 4, 5, 4);
-		rightUpperLeg2Mesh.position.y = -2.5;
+		const rightLeg2Box = new BoxGeometry(1, 12, 1, 1, 12, 1);
+		rightLeg2Box.translate(0, -6, 0);
+		applyLimbSkinning(rightLeg2Box);
+		const rightLeg2Mesh = new SkinnedMesh(rightLeg2Box, this.layer2MaterialBiased);
+		rightLeg2Mesh.scale.set(4.5, 1, 4.5);
+		setSkinUVs(rightLeg2Box, 0, 32, 4, 12, 4);
 
-		this.rightLegKnee = new Group();
-		this.rightLegKnee.name = "rightLegKnee";
-		this.rightLegKnee.position.y = -6;
+		const rightHip = new Bone();
+		const rightKnee = new Bone();
+		const rightAnkle = new Bone();
+		rightKnee.position.y = -6;
+		rightAnkle.position.y = -6;
+		rightHip.add(rightKnee);
+		rightKnee.add(rightAnkle);
+		const rightLegSkeleton = new Skeleton([rightHip, rightKnee, rightAnkle]);
+		rightLegMesh.add(rightHip);
+		rightLegMesh.bind(rightLegSkeleton);
+		rightLeg2Mesh.bind(rightLegSkeleton);
 
-		const rightKneeBox = new BoxGeometry();
-		const rightKneeMesh = new Mesh(rightKneeBox, this.layer1MaterialBiased);
-		rightKneeMesh.scale.set(4, 2, 4);
-		setSkinUVs(rightKneeBox, 0, 21, 4, 2, 4);
-		rightKneeMesh.position.y = 0;
+		this.rightLegKnee = rightKnee;
+		this.rightLegAnkle = rightAnkle;
 
-		const rightKnee2Box = new BoxGeometry();
-		const rightKnee2Mesh = new Mesh(rightKnee2Box, this.layer2MaterialBiased);
-		rightKnee2Mesh.scale.set(4.5, 2.5, 4.5);
-		setSkinUVs(rightKnee2Box, 0, 37, 4, 2, 4);
-		rightKnee2Mesh.position.y = 0;
-
-		this.rightLegJoint = new BodyPart(rightKneeMesh, rightKnee2Mesh);
-		this.rightLegJoint.name = "rightLegJoint";
-		this.rightLegJoint.add(rightKneeMesh, rightKnee2Mesh);
-		this.rightLegKnee.add(this.rightLegJoint);
-
-		const rightLowerLegBox = new BoxGeometry();
-		const rightLowerLegMesh = new Mesh(rightLowerLegBox, this.layer1MaterialBiased);
-		rightLowerLegMesh.scale.set(4, 5, 4);
-		setSkinUVs(rightLowerLegBox, 0, 23, 4, 5, 4);
-		rightLowerLegMesh.position.y = -2.5;
-
-		const rightLowerLeg2Box = new BoxGeometry();
-		const rightLowerLeg2Mesh = new Mesh(rightLowerLeg2Box, this.layer2MaterialBiased);
-		rightLowerLeg2Mesh.scale.set(4.5, 5.5, 4.5);
-		setSkinUVs(rightLowerLeg2Box, 0, 39, 4, 5, 4);
-		rightLowerLeg2Mesh.position.y = -2.5;
-
-		this.rightLegLower = new BodyPart(rightLowerLegMesh, rightLowerLeg2Mesh);
-		this.rightLegLower.name = "rightLegLower";
-		this.rightLegLower.position.y = -1;
-		this.rightLegLower.add(rightLowerLegMesh, rightLowerLeg2Mesh);
 		const rightFootBox = new BoxGeometry(4, 4, 4);
 		setSkinUVs(rightFootBox, 0, 24, 4, 4, 4);
 		const rightFootMesh = new Mesh(rightFootBox, this.layer1MaterialBiased);
 		rightFootMesh.position.y = -2;
-
 		const rightFoot2Box = new BoxGeometry(4.5, 4.5, 4.5);
 		setSkinUVs(rightFoot2Box, 0, 40, 4, 4, 4);
 		const rightFoot2Mesh = new Mesh(rightFoot2Box, this.layer2MaterialBiased);
 		rightFoot2Mesh.position.y = -2;
-
 		this.rightFoot = new BodyPart(rightFootMesh, rightFoot2Mesh);
 		this.rightFoot.name = "rightFoot";
-		this.rightFoot.position.y = -5;
-		this.rightLegLower.add(this.rightFoot);
-		this.rightLegKnee.add(this.rightLegLower);
+		this.rightLegAnkle.add(this.rightFoot);
 
-		this.rightLeg = new BodyPart(rightUpperLegMesh, rightUpperLeg2Mesh);
+		this.rightLeg = new BodyPart(rightLegMesh, rightLeg2Mesh);
 		this.rightLeg.name = "rightLeg";
-		this.rightLeg.add(rightUpperLegMesh, rightUpperLeg2Mesh, this.rightLegKnee);
+		rightLegMesh.add(rightLeg2Mesh);
+		this.rightLeg.add(rightLegMesh);
 		this.rightLeg.position.x = -1.9;
 		this.rightLeg.position.y = -12;
 		this.rightLeg.position.z = -0.1;
 		this.add(this.rightLeg);
 
 		// Left Leg
-		const leftUpperLegBox = new BoxGeometry();
-		const leftUpperLegMesh = new Mesh(leftUpperLegBox, this.layer1MaterialBiased);
-		leftUpperLegMesh.scale.set(4, 5, 4);
-		setSkinUVs(leftUpperLegBox, 16, 48, 4, 5, 4);
-		leftUpperLegMesh.position.y = -2.5;
+		const leftLegBox = new BoxGeometry(1, 12, 1, 1, 12, 1);
+		leftLegBox.translate(0, -6, 0);
+		applyLimbSkinning(leftLegBox);
+		const leftLegMesh = new SkinnedMesh(leftLegBox, this.layer1MaterialBiased);
+		leftLegMesh.scale.set(4, 1, 4);
+		setSkinUVs(leftLegBox, 16, 48, 4, 12, 4);
 
-		const leftUpperLeg2Box = new BoxGeometry();
-		const leftUpperLeg2Mesh = new Mesh(leftUpperLeg2Box, this.layer2MaterialBiased);
-		leftUpperLeg2Mesh.scale.set(4.5, 5.5, 4.5);
-		setSkinUVs(leftUpperLeg2Box, 0, 48, 4, 5, 4);
-		leftUpperLeg2Mesh.position.y = -2.5;
+		const leftLeg2Box = new BoxGeometry(1, 12, 1, 1, 12, 1);
+		leftLeg2Box.translate(0, -6, 0);
+		applyLimbSkinning(leftLeg2Box);
+		const leftLeg2Mesh = new SkinnedMesh(leftLeg2Box, this.layer2MaterialBiased);
+		leftLeg2Mesh.scale.set(4.5, 1, 4.5);
+		setSkinUVs(leftLeg2Box, 0, 48, 4, 12, 4);
 
-		this.leftLegKnee = new Group();
-		this.leftLegKnee.name = "leftLegKnee";
-		this.leftLegKnee.position.y = -6;
+		const leftHip = new Bone();
+		const leftKnee = new Bone();
+		const leftAnkle = new Bone();
+		leftKnee.position.y = -6;
+		leftAnkle.position.y = -6;
+		leftHip.add(leftKnee);
+		leftKnee.add(leftAnkle);
+		const leftLegSkeleton = new Skeleton([leftHip, leftKnee, leftAnkle]);
+		leftLegMesh.add(leftHip);
+		leftLegMesh.bind(leftLegSkeleton);
+		leftLeg2Mesh.bind(leftLegSkeleton);
 
-		const leftKneeBox = new BoxGeometry();
-		const leftKneeMesh = new Mesh(leftKneeBox, this.layer1MaterialBiased);
-		leftKneeMesh.scale.set(4, 2, 4);
-		setSkinUVs(leftKneeBox, 16, 53, 4, 2, 4);
-		leftKneeMesh.position.y = 0;
+		this.leftLegKnee = leftKnee;
+		this.leftLegAnkle = leftAnkle;
 
-		const leftKnee2Box = new BoxGeometry();
-		const leftKnee2Mesh = new Mesh(leftKnee2Box, this.layer2MaterialBiased);
-		leftKnee2Mesh.scale.set(4.5, 2.5, 4.5);
-		setSkinUVs(leftKnee2Box, 0, 53, 4, 2, 4);
-		leftKnee2Mesh.position.y = 0;
-
-		this.leftLegJoint = new BodyPart(leftKneeMesh, leftKnee2Mesh);
-		this.leftLegJoint.name = "leftLegJoint";
-		this.leftLegJoint.add(leftKneeMesh, leftKnee2Mesh);
-		this.leftLegKnee.add(this.leftLegJoint);
-
-		const leftLowerLegBox = new BoxGeometry();
-		const leftLowerLegMesh = new Mesh(leftLowerLegBox, this.layer1MaterialBiased);
-		leftLowerLegMesh.scale.set(4, 5, 4);
-		setSkinUVs(leftLowerLegBox, 16, 55, 4, 5, 4);
-		leftLowerLegMesh.position.y = -2.5;
-
-		const leftLowerLeg2Box = new BoxGeometry();
-		const leftLowerLeg2Mesh = new Mesh(leftLowerLeg2Box, this.layer2MaterialBiased);
-		leftLowerLeg2Mesh.scale.set(4.5, 5.5, 4.5);
-		setSkinUVs(leftLowerLeg2Box, 0, 55, 4, 5, 4);
-		leftLowerLeg2Mesh.position.y = -2.5;
-
-		this.leftLegLower = new BodyPart(leftLowerLegMesh, leftLowerLeg2Mesh);
-		this.leftLegLower.name = "leftLegLower";
-		this.leftLegLower.position.y = -1;
-		this.leftLegLower.add(leftLowerLegMesh, leftLowerLeg2Mesh);
 		const leftFootBox = new BoxGeometry(4, 4, 4);
 		setSkinUVs(leftFootBox, 16, 56, 4, 4, 4);
 		const leftFootMesh = new Mesh(leftFootBox, this.layer1MaterialBiased);
 		leftFootMesh.position.y = -2;
-
 		const leftFoot2Box = new BoxGeometry(4.5, 4.5, 4.5);
 		setSkinUVs(leftFoot2Box, 0, 56, 4, 4, 4);
 		const leftFoot2Mesh = new Mesh(leftFoot2Box, this.layer2MaterialBiased);
 		leftFoot2Mesh.position.y = -2;
-
 		this.leftFoot = new BodyPart(leftFootMesh, leftFoot2Mesh);
 		this.leftFoot.name = "leftFoot";
-		this.leftFoot.position.y = -5;
-		this.leftLegLower.add(this.leftFoot);
-		this.leftLegKnee.add(this.leftLegLower);
+		this.leftLegAnkle.add(this.leftFoot);
 
-		this.leftLeg = new BodyPart(leftUpperLegMesh, leftUpperLeg2Mesh);
+		this.leftLeg = new BodyPart(leftLegMesh, leftLeg2Mesh);
 		this.leftLeg.name = "leftLeg";
-		this.leftLeg.add(leftUpperLegMesh, leftUpperLeg2Mesh, this.leftLegKnee);
+		leftLegMesh.add(leftLeg2Mesh);
+		this.leftLeg.add(leftLegMesh);
 		this.leftLeg.position.x = 1.9;
 		this.leftLeg.position.y = -12;
 		this.leftLeg.position.z = -0.1;
@@ -594,72 +475,31 @@ export class SkinObject extends Group {
 		this.leftFoot.rotation.set(0, 0, 0);
 		this.rightArmElbow.rotation.set(0, 0, 0);
 		this.leftArmElbow.rotation.set(0, 0, 0);
+		this.rightArmWrist.rotation.set(0, 0, 0);
+		this.leftArmWrist.rotation.set(0, 0, 0);
 		this.rightLegKnee.rotation.set(0, 0, 0);
 		this.leftLegKnee.rotation.set(0, 0, 0);
+		this.rightLegAnkle.rotation.set(0, 0, 0);
+		this.leftLegAnkle.rotation.set(0, 0, 0);
 		this.rightArmElbow.position.set(0, -6, 0);
+		this.rightArmWrist.position.set(0, -6, 0);
 		this.leftArmElbow.position.set(0, -6, 0);
+		this.leftArmWrist.position.set(0, -6, 0);
 		this.rightLegKnee.position.set(0, -6, 0);
+		this.rightLegAnkle.position.set(0, -6, 0);
 		this.leftLegKnee.position.set(0, -6, 0);
-		(this.rightArm.innerLayer as Mesh).position.set(0, -2.5, 0);
-		(this.rightArm.outerLayer as Mesh).position.set(0, -2.5, 0);
-		(this.leftArm.innerLayer as Mesh).position.set(0, -2.5, 0);
-		(this.leftArm.outerLayer as Mesh).position.set(0, -2.5, 0);
-		this.rightArmJoint.rotation.set(0, 0, 0);
-		this.rightArmJoint.position.set(0, 0, 0);
-		(this.rightArmJoint.innerLayer as Mesh).position.set(0, 0, 0);
-		(this.rightArmJoint.outerLayer as Mesh).position.set(0, 0, 0);
-		this.leftArmJoint.rotation.set(0, 0, 0);
-		this.leftArmJoint.position.set(0, 0, 0);
-		(this.leftArmJoint.innerLayer as Mesh).position.set(0, 0, 0);
-		(this.leftArmJoint.outerLayer as Mesh).position.set(0, 0, 0);
-		this.rightLegJoint.rotation.set(0, 0, 0);
-		this.rightLegJoint.position.set(0, 0, 0);
-		(this.rightLegJoint.innerLayer as Mesh).position.set(0, 0, 0);
-		(this.rightLegJoint.outerLayer as Mesh).position.set(0, 0, 0);
-		this.leftLegJoint.rotation.set(0, 0, 0);
-		this.leftLegJoint.position.set(0, 0, 0);
-		(this.leftLegJoint.innerLayer as Mesh).position.set(0, 0, 0);
-		(this.leftLegJoint.outerLayer as Mesh).position.set(0, 0, 0);
-		this.rightArmLower.rotation.set(0, 0, 0);
-		this.rightArmLower.position.set(0, -1, 0);
-		(this.rightArmLower.innerLayer as Mesh).position.set(0, -2.5, 0);
-		(this.rightArmLower.outerLayer as Mesh).position.set(0, -2.5, 0);
-		this.rightHand.position.set(0, -5, 0);
-		this.leftArmLower.rotation.set(0, 0, 0);
-		this.leftArmLower.position.set(0, -1, 0);
-		(this.leftArmLower.innerLayer as Mesh).position.set(0, -2.5, 0);
-		(this.leftArmLower.outerLayer as Mesh).position.set(0, -2.5, 0);
-		this.leftHand.position.set(0, -5, 0);
-		this.rightLegLower.rotation.set(0, 0, 0);
-		this.rightLegLower.position.set(0, -1, 0);
-		(this.rightLeg.innerLayer as Mesh).position.set(0, -2.5, 0);
-		(this.rightLeg.outerLayer as Mesh).position.set(0, -2.5, 0);
-		(this.rightLegLower.innerLayer as Mesh).position.set(0, -2.5, 0);
-		(this.rightLegLower.outerLayer as Mesh).position.set(0, -2.5, 0);
-		this.rightFoot.position.set(0, -5, 0);
-		this.leftLegLower.rotation.set(0, 0, 0);
-		this.leftLegLower.position.set(0, -1, 0);
-		(this.leftLeg.innerLayer as Mesh).position.set(0, -2.5, 0);
-		(this.leftLeg.outerLayer as Mesh).position.set(0, -2.5, 0);
-		(this.leftLegLower.innerLayer as Mesh).position.set(0, -2.5, 0);
-		(this.leftLegLower.outerLayer as Mesh).position.set(0, -2.5, 0);
-		this.leftFoot.position.set(0, -5, 0);
+		this.leftLegAnkle.position.set(0, -6, 0);
+		this.rightHand.position.set(0, 0, 0);
+		this.leftHand.position.set(0, 0, 0);
+		this.rightFoot.position.set(0, 0, 0);
+		this.leftFoot.position.set(0, 0, 0);
 		this.body.rotation.set(0, 0, 0);
 		this.head.position.y = 0;
-		this.body.position.y = -6;
-		this.body.position.z = 0;
-		this.rightArm.position.x = -5;
-		this.rightArm.position.y = -2;
-		this.rightArm.position.z = 0;
-		this.leftArm.position.x = 5;
-		this.leftArm.position.y = -2;
-		this.leftArm.position.z = 0;
-		this.rightLeg.position.x = -1.9;
-		this.rightLeg.position.y = -12;
-		this.rightLeg.position.z = -0.1;
-		this.leftLeg.position.x = 1.9;
-		this.leftLeg.position.y = -12;
-		this.leftLeg.position.z = -0.1;
+		this.body.position.set(0, -6, 0);
+		this.rightArm.position.set(-5, -2, 0);
+		this.leftArm.position.set(5, -2, 0);
+		this.rightLeg.position.set(-1.9, -12, -0.1);
+		this.leftLeg.position.set(1.9, -12, -0.1);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace limb segments with single skinned meshes using shoulder/elbow/wrist and hip/knee/ankle bone chains
- BendAnimation distributes rotations across new limb bones for smooth curves
- Update examples and IK setup to reference wrist and ankle bones

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689506ee5e5483278b658ac5eba73581