### PR TITLE
feat(viewer): support per-player animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ skinViewer.animation = null;
 </script>
 ```
 
+To control animations for additional `PlayerObject` instances added to the scene, use
+`setAnimation(player, animation)` and `getAnimation(player)` to assign or retrieve the
+animation for a specific player.
+
 ```js
 import { SkinViewer, BendAnimation } from "skinview3d";
 


### PR DESCRIPTION
## Summary
- track animations per `PlayerObject` via a Map
- add `setAnimation`/`getAnimation` API while keeping `animation` property for the main player
- update render loop to step every player's animation and document multi-player usage

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895ff53630883278f8246b35988647d