### PR TITLE
feat: add multi-model controls to example

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -16,16 +16,9 @@
 			}
 
 			#skin_container {
-				width: 400px;
-				height: 600px;
 				position: sticky;
 				top: 20px;
 				align-self: flex-start;
-			}
-
-			#skin_container.expanded {
-				width: 800px;
-				height: 600px;
 			}
 
 			.controls {
@@ -85,6 +78,9 @@
 
 		<div class="controls">
 			<button id="reset_all" type="button" class="control">Reset All</button>
+			<button id="add_model" type="button" class="control">Add Model</button>
+			<button id="remove_model" type="button" class="control">Remove Model</button>
+			<div id="extra_player_controls" class="control-section"></div>
 
 			<div class="control-section">
 				<h1>Debug</h1>

--- a/examples/style.css
+++ b/examples/style.css
@@ -96,6 +96,16 @@ label {
 	display: none;
 }
 
+#skin_container {
+	width: 400px;
+	height: 600px;
+}
+
+#skin_container.expanded {
+	width: 800px;
+	height: 600px;
+}
+
 #timeline {
 	border: 1px solid #ccc;
 	margin: 10px 0;


### PR DESCRIPTION
## Summary
- add buttons to add and remove player models in example page
- expand viewer canvas when multiple models are displayed
- manage per-player animations with dynamic selectors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895ff5466ec83278c2f078e512e1c71