### PR TITLE
Optimize auto-fit layout updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ skinViewer.animation = new BendAnimation();
 You can add more player models to the scene with `addPlayer()`. Pass the returned
 `PlayerObject` to texture-loading methods to control each player independently.
 
+When `autoFit` is enabled (default), the viewer repositions players and adjusts
+the camera after `addPlayer()` or `removePlayer()`. If you disable `autoFit`,
+call `updateLayout()` whenever players are added or removed to keep them
+centered.
+
 ```ts
 import { SkinViewer } from "skinview3d";
 
@@ -131,6 +136,13 @@ viewer.loadSkin("img/first.png");
 viewer.loadSkin("img/second.png", {}, second);
 viewer.loadCape("img/cape.png", {}, second);
 viewer.loadEars("img/ears.png", { textureType: "standalone" }, second);
+```
+
+```ts
+// Disable automatic layout and trigger it manually when needed
+viewer.autoFit = false;
+// ... add or remove players ...
+viewer.updateLayout();
 ```
 
 ### Keyframe animations

--- a/examples/index.html
+++ b/examples/index.html
@@ -80,6 +80,7 @@
 			<button id="reset_all" type="button" class="control">Reset All</button>
 			<button id="add_model" type="button" class="control">Add Model</button>
 			<button id="remove_model" type="button" class="control">Remove Model</button>
+			<label class="control"><input id="auto_fit" type="checkbox" checked /> Auto-fit players</label>
 			<div id="extra_player_controls" class="control-section"></div>
 
 			<div class="control-section">

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -209,6 +209,7 @@ function addModel(): void {
 		extraPlayerControls.push(div);
 	}
 	updateViewportSize();
+	skinViewer.updateLayout();
 }
 
 function removeModel(): void {
@@ -220,6 +221,7 @@ function removeModel(): void {
 	const control = extraPlayerControls.pop();
 	control?.remove();
 	updateViewportSize();
+	skinViewer.updateLayout();
 }
 
 function obtainTextureUrl(id: string): string {
@@ -860,6 +862,7 @@ function initializeViewer(): void {
 	const controlZoom = document.getElementById("control_zoom") as HTMLInputElement;
 	const controlPan = document.getElementById("control_pan") as HTMLInputElement;
 	const animationSpeed = document.getElementById("animation_speed") as HTMLInputElement;
+	const autoFit = document.getElementById("auto_fit") as HTMLInputElement;
 
 	skinViewer.width = Number(canvasWidth?.value);
 	skinViewer.height = Number(canvasHeight?.value);
@@ -869,6 +872,7 @@ function initializeViewer(): void {
 	skinViewer.cameraLight.intensity = Number(cameraLight?.value);
 	skinViewer.autoRotate = autoRotate?.checked ?? false;
 	skinViewer.autoRotateSpeed = Number(autoRotateSpeed?.value);
+	skinViewer.autoFit = autoFit?.checked ?? true;
 
 	const animationRadio = document.querySelector<HTMLInputElement>('input[type="radio"][name="animation"]:checked');
 	const animationName = animationRadio?.value;
@@ -883,6 +887,10 @@ function initializeViewer(): void {
 	skinViewer.controls.enableRotate = controlRotate?.checked ?? false;
 	skinViewer.controls.enableZoom = controlZoom?.checked ?? false;
 	skinViewer.controls.enablePan = controlPan?.checked ?? false;
+
+	autoFit?.addEventListener("change", () => {
+		skinViewer.autoFit = autoFit.checked;
+	});
 
 	for (const part of skinParts) {
 		const skinPart = (skinViewer.playerObject.skin as any)[part];

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -335,6 +335,24 @@ export class SkinViewer {
 	 */
 	autoRotateSpeed: number = 1.0;
 
+	/**
+	 * Whether to automatically position players and adjust the camera so all players are visible.
+	 *
+	 * @defaultValue `true`
+	 */
+	private _autoFit: boolean = true;
+
+	get autoFit(): boolean {
+		return this._autoFit;
+	}
+
+	set autoFit(value: boolean) {
+		if (this._autoFit !== value) {
+			this._autoFit = value;
+			this.updateLayout();
+		}
+	}
+
 	private animations: Map<PlayerObject, PlayerAnimation>;
 	private _animation: PlayerAnimation | null = null;
 	private clock: Clock;
@@ -737,6 +755,9 @@ export class SkinViewer {
 		this.applySkinPlaceholder(player);
 		this.players.push(player);
 		this.playerWrapper.add(player);
+		if (this.autoFit) {
+			this.updateLayout();
+		}
 		return player;
 	}
 
@@ -758,6 +779,27 @@ export class SkinViewer {
 			this.skinTextures.delete(player);
 			this.capeTextures.delete(player);
 			this.earsTextures.delete(player);
+		}
+		if (this.autoFit) {
+			this.updateLayout();
+		}
+	}
+
+	/**
+	 * Positions players evenly and adjusts the camera distance.
+	 * Calling this method is necessary after adding or removing players when {@link autoFit} is disabled.
+	 */
+	updateLayout(): void {
+		this.layoutPlayers();
+		this.adjustCameraDistance();
+	}
+
+	private layoutPlayers(): void {
+		const count = this.players.length;
+		const spacing = 20;
+		const offset = ((count - 1) * spacing) / 2;
+		for (let i = 0; i < count; i++) {
+			this.players[i].position.x = i * spacing - offset;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add `autoFit` flag and `updateLayout()` method to control when players are repositioned
- call `updateLayout()` after adding/removing players and when toggling auto-fit
- document new auto-fit triggers and update example with auto-fit toggle

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68961585d13483279acd73891f7995dc