### PR TITLE
style: stack example controls vertically

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -4,6 +4,7 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>skinview3d</title>
+		<link rel="stylesheet" href="./style.css" />
 		<style>
 			body {
 				margin: 0;

--- a/examples/style.css
+++ b/examples/style.css
@@ -26,11 +26,35 @@ input[type="text"] {
 }
 
 .control {
-	display: inline;
+	display: flex;
+	flex-direction: column;
 }
 
 .control + .control {
-	margin-left: 10px;
+	margin-left: 0;
+	margin-top: 10px;
+}
+
+.dropdown {
+	position: relative;
+	display: block;
+}
+
+.dropdown-menu {
+	display: none;
+	position: absolute;
+	left: 0;
+	top: 100%;
+	margin-top: 4px;
+	padding: 4px 0;
+	background: #fff;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	z-index: 1000;
+}
+
+.dropdown.open .dropdown-menu {
+	display: block;
 }
 
 .control-section {
@@ -94,6 +118,13 @@ label {
 
 .hidden {
 	display: none;
+}
+
+#extra_player_controls {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	max-width: 100%;
 }
 
 #skin_container {


### PR DESCRIPTION
## Summary
- Stack example controls vertically using a flex-column layout
- Add dropdown menu and extra controls styles for responsive layout
- Load shared stylesheet in example page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896171fc4b883279369da20aa5b036b