### PR TITLE
refactor: rename limb segments and joints

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,15 +157,15 @@ const anim = new KeyframeAnimation({
     {
       time: 0,
       bones: {
-        "skin.leftArm": [0, 0, 0],
-        "skin.rightArm": [0, 0, 0],
+        "skin.leftUpperArm": [0, 0, 0],
+        "skin.rightUpperArm": [0, 0, 0],
       },
     },
     {
       time: 1,
       bones: {
-        "skin.leftArm": [Math.PI / 2, 0, 0],
-        "skin.rightArm": [-Math.PI / 2, 0, 0],
+        "skin.leftUpperArm": [Math.PI / 2, 0, 0],
+        "skin.rightUpperArm": [-Math.PI / 2, 0, 0],
       },
     },
   ],
@@ -187,7 +187,7 @@ interface KeyframeData {
 }
 ```
 
-Bone names are dotted paths relative to the `PlayerObject`, such as `"skin.leftArm"` or `"cape"`.
+Bone names are dotted paths relative to the `PlayerObject`, such as `"skin.leftUpperArm"` or `"cape"`.
 
 ```html
 <!-- Upload a new skin (the same approach works for capes, armor, items, panoramas, etc.) -->

--- a/examples/index.html
+++ b/examples/index.html
@@ -100,14 +100,18 @@
 							<option value="playerObject">Player</option>
 							<option value="skin.head">skin.head</option>
 							<option value="skin.body">skin.body</option>
-							<option value="skin.rightArm">skin.rightArm</option>
-							<option value="skin.rightArmElbow">skin.rightArmElbow</option>
-							<option value="skin.leftArm">skin.leftArm</option>
-							<option value="skin.leftArmElbow">skin.leftArmElbow</option>
-							<option value="skin.rightLeg">skin.rightLeg</option>
-							<option value="skin.rightLegKnee">skin.rightLegKnee</option>
-							<option value="skin.leftLeg">skin.leftLeg</option>
-							<option value="skin.leftLegKnee">skin.leftLegKnee</option>
+							<option value="skin.rightUpperArm">skin.rightUpperArm</option>
+							<option value="skin.rightElbow">skin.rightElbow</option>
+							<option value="skin.rightLowerArm">skin.rightLowerArm</option>
+							<option value="skin.leftUpperArm">skin.leftUpperArm</option>
+							<option value="skin.leftElbow">skin.leftElbow</option>
+							<option value="skin.leftLowerArm">skin.leftLowerArm</option>
+							<option value="skin.rightUpperLeg">skin.rightUpperLeg</option>
+							<option value="skin.rightKnee">skin.rightKnee</option>
+							<option value="skin.rightLowerLeg">skin.rightLowerLeg</option>
+							<option value="skin.leftUpperLeg">skin.leftUpperLeg</option>
+							<option value="skin.leftKnee">skin.leftKnee</option>
+							<option value="skin.leftLowerLeg">skin.leftLowerLeg</option>
 							<option value="ik.rightArm">IK: Right Arm</option>
 							<option value="ik.leftArm">IK: Left Arm</option>
 							<option value="ik.rightLeg">IK: Right Leg</option>
@@ -231,10 +235,10 @@
 							<th></th>
 							<th>head</th>
 							<th>body</th>
-							<th>right arm</th>
-							<th>left arm</th>
-							<th>right leg</th>
-							<th>left leg</th>
+							<th>right upper arm</th>
+							<th>left upper arm</th>
+							<th>right upper leg</th>
+							<th>left upper leg</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -242,19 +246,19 @@
 							<th>inner</th>
 							<td><input type="checkbox" data-layer="innerLayer" data-part="head" checked /></td>
 							<td><input type="checkbox" data-layer="innerLayer" data-part="body" checked /></td>
-							<td><input type="checkbox" data-layer="innerLayer" data-part="rightArm" checked /></td>
-							<td><input type="checkbox" data-layer="innerLayer" data-part="leftArm" checked /></td>
-							<td><input type="checkbox" data-layer="innerLayer" data-part="rightLeg" checked /></td>
-							<td><input type="checkbox" data-layer="innerLayer" data-part="leftLeg" checked /></td>
+							<td><input type="checkbox" data-layer="innerLayer" data-part="rightUpperArm" checked /></td>
+							<td><input type="checkbox" data-layer="innerLayer" data-part="leftUpperArm" checked /></td>
+							<td><input type="checkbox" data-layer="innerLayer" data-part="rightUpperLeg" checked /></td>
+							<td><input type="checkbox" data-layer="innerLayer" data-part="leftUpperLeg" checked /></td>
 						</tr>
 						<tr>
 							<th>outer</th>
 							<td><input type="checkbox" data-layer="outerLayer" data-part="head" checked /></td>
 							<td><input type="checkbox" data-layer="outerLayer" data-part="body" checked /></td>
-							<td><input type="checkbox" data-layer="outerLayer" data-part="rightArm" checked /></td>
-							<td><input type="checkbox" data-layer="outerLayer" data-part="leftArm" checked /></td>
-							<td><input type="checkbox" data-layer="outerLayer" data-part="rightLeg" checked /></td>
-							<td><input type="checkbox" data-layer="outerLayer" data-part="leftLeg" checked /></td>
+							<td><input type="checkbox" data-layer="outerLayer" data-part="rightUpperArm" checked /></td>
+							<td><input type="checkbox" data-layer="outerLayer" data-part="leftUpperArm" checked /></td>
+							<td><input type="checkbox" data-layer="outerLayer" data-part="rightUpperLeg" checked /></td>
+							<td><input type="checkbox" data-layer="outerLayer" data-part="leftUpperLeg" checked /></td>
 						</tr>
 					</tbody>
 				</table>

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -11,22 +11,18 @@ import { GeneratedAnimation } from "./generated-animation";
 const skinParts = [
 	"head",
 	"body",
-	"rightArm",
-	"leftArm",
-	"rightLeg",
-	"leftLeg",
-	"rightArmElbow",
-	"leftArmElbow",
-	"rightLegKnee",
-	"leftLegKnee",
-	"rightArmWrist",
-	"leftArmWrist",
-	"rightLegAnkle",
-	"leftLegAnkle",
-	"rightHand",
-	"leftHand",
-	"rightFoot",
-	"leftFoot",
+	"rightUpperArm",
+	"leftUpperArm",
+	"rightUpperLeg",
+	"leftUpperLeg",
+	"rightElbow",
+	"leftElbow",
+	"rightKnee",
+	"leftKnee",
+	"rightLowerArm",
+	"leftLowerArm",
+	"rightLowerLeg",
+	"leftLowerLeg",
 ];
 const skinLayers = ["innerLayer", "outerLayer"];
 const animationClasses = {
@@ -66,18 +62,14 @@ function updateJointHighlight(enabled: boolean): void {
 	jointHelpers = [];
 	if (enabled) {
 		const joints = [
-			skinViewer.playerObject.skin.rightArmElbow,
-			skinViewer.playerObject.skin.leftArmElbow,
-			skinViewer.playerObject.skin.rightArmWrist,
-			skinViewer.playerObject.skin.leftArmWrist,
-			skinViewer.playerObject.skin.rightLegKnee,
-			skinViewer.playerObject.skin.leftLegKnee,
-			skinViewer.playerObject.skin.rightLegAnkle,
-			skinViewer.playerObject.skin.leftLegAnkle,
-			skinViewer.playerObject.skin.rightHand,
-			skinViewer.playerObject.skin.leftHand,
-			skinViewer.playerObject.skin.rightFoot,
-			skinViewer.playerObject.skin.leftFoot,
+			skinViewer.playerObject.skin.rightElbow,
+			skinViewer.playerObject.skin.leftElbow,
+			skinViewer.playerObject.skin.rightLowerArm,
+			skinViewer.playerObject.skin.leftLowerArm,
+			skinViewer.playerObject.skin.rightKnee,
+			skinViewer.playerObject.skin.leftKnee,
+			skinViewer.playerObject.skin.rightLowerLeg,
+			skinViewer.playerObject.skin.leftLowerLeg,
 		];
 		for (const joint of joints) {
 			const helper = new BoxHelper(joint, 0xff0000);
@@ -421,93 +413,89 @@ function setupIK(): void {
 	}
 	const skin = skinViewer.playerObject.skin;
 
-	const rightHandTarget = new Object3D();
-	const rightHandMesh = new Mesh(new SphereGeometry(0.5), new MeshBasicMaterial({ color: 0xff0000 }));
-	rightHandTarget.add(rightHandMesh);
+	const rightLowerArmTarget = new Object3D();
+	const rightLowerArmMesh = new Mesh(new SphereGeometry(0.5), new MeshBasicMaterial({ color: 0xff0000 }));
+	rightLowerArmTarget.add(rightLowerArmMesh);
 
-	rightHandTarget.position.copy(skin.rightHand.getWorldPosition(new Vector3()));
-	skinViewer.scene.add(rightHandTarget);
+	rightLowerArmTarget.position.copy(skin.rightLowerArm.getWorldPosition(new Vector3()));
+	skinViewer.scene.add(rightLowerArmTarget);
 	const rIK = new IK();
 	const rChain = new IKChain();
-	const rRoot = new IKJoint(skin.rightArm);
+	const rRoot = new IKJoint(skin.rightUpperArm);
 	rChain.add(rRoot); // keep shoulder static
-	rChain.add(new IKJoint(skin.rightArmElbow));
-	rChain.add(new IKJoint(skin.rightArmWrist));
-	rChain.add(new IKJoint(skin.rightHand), { target: rightHandTarget });
+	rChain.add(new IKJoint(skin.rightElbow));
+	rChain.add(new IKJoint(skin.rightLowerArm), { target: rightLowerArmTarget });
 	rChain.effectorIndex = rChain.joints.length - 1;
 	rIK.add(rChain);
 	ikChains["ik.rightArm"] = {
-		target: rightHandTarget,
+		target: rightLowerArmTarget,
 		ik: rIK,
-		bones: ["skin.rightArm", "skin.rightArmElbow", "skin.rightArmWrist", "skin.rightHand"],
+		bones: ["skin.rightUpperArm", "skin.rightElbow", "skin.rightLowerArm"],
 		root: rRoot,
 	};
 
-	const leftHandTarget = new Object3D();
-	const leftHandMesh = new Mesh(new SphereGeometry(0.5), new MeshBasicMaterial({ color: 0x00ff00 }));
-	leftHandTarget.add(leftHandMesh);
+	const leftLowerArmTarget = new Object3D();
+	const leftLowerArmMesh = new Mesh(new SphereGeometry(0.5), new MeshBasicMaterial({ color: 0x00ff00 }));
+	leftLowerArmTarget.add(leftLowerArmMesh);
 
-	leftHandTarget.position.copy(skin.leftHand.getWorldPosition(new Vector3()));
-	skinViewer.scene.add(leftHandTarget);
+	leftLowerArmTarget.position.copy(skin.leftLowerArm.getWorldPosition(new Vector3()));
+	skinViewer.scene.add(leftLowerArmTarget);
 	const lIK = new IK();
 	const lChain = new IKChain();
-	const lRoot = new IKJoint(skin.leftArm);
+	const lRoot = new IKJoint(skin.leftUpperArm);
 	lChain.add(lRoot); // keep shoulder static
-	lChain.add(new IKJoint(skin.leftArmElbow));
-	lChain.add(new IKJoint(skin.leftArmWrist));
-	lChain.add(new IKJoint(skin.leftHand), { target: leftHandTarget });
+	lChain.add(new IKJoint(skin.leftElbow));
+	lChain.add(new IKJoint(skin.leftLowerArm), { target: leftLowerArmTarget });
 	lChain.effectorIndex = lChain.joints.length - 1;
 	lIK.add(lChain);
 	ikChains["ik.leftArm"] = {
-		target: leftHandTarget,
+		target: leftLowerArmTarget,
 
 		ik: lIK,
-		bones: ["skin.leftArm", "skin.leftArmElbow", "skin.leftArmWrist", "skin.leftHand"],
+		bones: ["skin.leftUpperArm", "skin.leftElbow", "skin.leftLowerArm"],
 		root: lRoot,
 	};
 
-	const rightFootTarget = new Object3D();
-	const rightFootMesh = new Mesh(new SphereGeometry(0.5), new MeshBasicMaterial({ color: 0x0000ff }));
-	rightFootTarget.add(rightFootMesh);
+	const rightLowerLegTarget = new Object3D();
+	const rightLowerLegMesh = new Mesh(new SphereGeometry(0.5), new MeshBasicMaterial({ color: 0x0000ff }));
+	rightLowerLegTarget.add(rightLowerLegMesh);
 
-	rightFootTarget.position.copy(skin.rightFoot.getWorldPosition(new Vector3()));
-	skinViewer.scene.add(rightFootTarget);
+	rightLowerLegTarget.position.copy(skin.rightLowerLeg.getWorldPosition(new Vector3()));
+	skinViewer.scene.add(rightLowerLegTarget);
 	const rLegIK = new IK();
 	const rLegChain = new IKChain();
-	const rLegRoot = new IKJoint(skin.rightLeg);
+	const rLegRoot = new IKJoint(skin.rightUpperLeg);
 	rLegChain.add(rLegRoot); // keep hip static
-	rLegChain.add(new IKJoint(skin.rightLegKnee));
-	rLegChain.add(new IKJoint(skin.rightLegAnkle));
-	rLegChain.add(new IKJoint(skin.rightFoot), { target: rightFootTarget });
+	rLegChain.add(new IKJoint(skin.rightKnee));
+	rLegChain.add(new IKJoint(skin.rightLowerLeg), { target: rightLowerLegTarget });
 	rLegChain.effectorIndex = rLegChain.joints.length - 1;
 	rLegIK.add(rLegChain);
 	ikChains["ik.rightLeg"] = {
-		target: rightFootTarget,
+		target: rightLowerLegTarget,
 
 		ik: rLegIK,
-		bones: ["skin.rightLeg", "skin.rightLegKnee", "skin.rightLegAnkle", "skin.rightFoot"],
+		bones: ["skin.rightUpperLeg", "skin.rightKnee", "skin.rightLowerLeg"],
 		root: rLegRoot,
 	};
 
-	const leftFootTarget = new Object3D();
-	const leftFootMesh = new Mesh(new SphereGeometry(0.5), new MeshBasicMaterial({ color: 0xffff00 }));
-	leftFootTarget.add(leftFootMesh);
+	const leftLowerLegTarget = new Object3D();
+	const leftLowerLegMesh = new Mesh(new SphereGeometry(0.5), new MeshBasicMaterial({ color: 0xffff00 }));
+	leftLowerLegTarget.add(leftLowerLegMesh);
 
-	leftFootTarget.position.copy(skin.leftFoot.getWorldPosition(new Vector3()));
-	skinViewer.scene.add(leftFootTarget);
+	leftLowerLegTarget.position.copy(skin.leftLowerLeg.getWorldPosition(new Vector3()));
+	skinViewer.scene.add(leftLowerLegTarget);
 	const lLegIK = new IK();
 	const lLegChain = new IKChain();
-	const lLegRoot = new IKJoint(skin.leftLeg);
+	const lLegRoot = new IKJoint(skin.leftUpperLeg);
 	lLegChain.add(lLegRoot); // keep hip static
-	lLegChain.add(new IKJoint(skin.leftLegKnee));
-	lLegChain.add(new IKJoint(skin.leftLegAnkle));
-	lLegChain.add(new IKJoint(skin.leftFoot), { target: leftFootTarget });
+	lLegChain.add(new IKJoint(skin.leftKnee));
+	lLegChain.add(new IKJoint(skin.leftLowerLeg), { target: leftLowerLegTarget });
 	lLegChain.effectorIndex = lLegChain.joints.length - 1;
 	lLegIK.add(lLegChain);
 	ikChains["ik.leftLeg"] = {
-		target: leftFootTarget,
+		target: leftLowerLegTarget,
 		ik: lLegIK,
-		bones: ["skin.leftLeg", "skin.leftLegKnee", "skin.leftLegAnkle", "skin.leftFoot"],
+		bones: ["skin.leftUpperLeg", "skin.leftKnee", "skin.leftLowerLeg"],
 		root: lLegRoot,
 	};
 
@@ -952,7 +940,10 @@ function initializeBoneSelector(useIK = false): void {
 	selector.appendChild(playerOption);
 
 	for (const part of skinParts) {
-		if (useIK && (part === "rightArm" || part === "leftArm" || part === "rightLeg" || part === "leftLeg")) {
+		if (
+			useIK &&
+			(part === "rightUpperArm" || part === "leftUpperArm" || part === "rightUpperLeg" || part === "leftUpperLeg")
+		) {
 			continue;
 		}
 		const option = document.createElement("option");

--- a/src/animation.ts
+++ b/src/animation.ts
@@ -123,7 +123,7 @@ export interface KeyframeData {
 }
 
 /**
- * Resolve a dotted bone path (e.g. "skin.leftArm") to the corresponding object
+ * Resolve a dotted bone path (e.g. "skin.leftUpperArm") to the corresponding object
  * on the player model.
  */
 function resolveBone(player: PlayerObject, path: string): any {
@@ -220,8 +220,8 @@ export class IdleAnimation extends PlayerAnimation {
 
 		// Arm swing
 		const basicArmRotationZ = Math.PI * 0.02;
-		player.skin.leftArm.rotation.z = Math.cos(t) * 0.03 + basicArmRotationZ;
-		player.skin.rightArm.rotation.z = Math.cos(t + Math.PI) * 0.03 - basicArmRotationZ;
+		player.skin.leftUpperArm.rotation.z = Math.cos(t) * 0.03 + basicArmRotationZ;
+		player.skin.rightUpperArm.rotation.z = Math.cos(t + Math.PI) * 0.03 - basicArmRotationZ;
 
 		// Always add an angle for cape around the x axis
 		const basicCapeRotationX = Math.PI * 0.06;
@@ -242,15 +242,15 @@ export class WalkingAnimation extends PlayerAnimation {
 		const t = this.progress * 8;
 
 		// Leg swing
-		player.skin.leftLeg.rotation.x = Math.sin(t) * 0.5;
-		player.skin.rightLeg.rotation.x = Math.sin(t + Math.PI) * 0.5;
+		player.skin.leftUpperLeg.rotation.x = Math.sin(t) * 0.5;
+		player.skin.rightUpperLeg.rotation.x = Math.sin(t + Math.PI) * 0.5;
 
 		// Arm swing
-		player.skin.leftArm.rotation.x = Math.sin(t + Math.PI) * 0.5;
-		player.skin.rightArm.rotation.x = Math.sin(t) * 0.5;
+		player.skin.leftUpperArm.rotation.x = Math.sin(t + Math.PI) * 0.5;
+		player.skin.rightUpperArm.rotation.x = Math.sin(t) * 0.5;
 		const basicArmRotationZ = Math.PI * 0.02;
-		player.skin.leftArm.rotation.z = Math.cos(t) * 0.03 + basicArmRotationZ;
-		player.skin.rightArm.rotation.z = Math.cos(t + Math.PI) * 0.03 - basicArmRotationZ;
+		player.skin.leftUpperArm.rotation.z = Math.cos(t) * 0.03 + basicArmRotationZ;
+		player.skin.rightUpperArm.rotation.z = Math.cos(t + Math.PI) * 0.03 - basicArmRotationZ;
 
 		if (this.headBobbing) {
 			// Head shaking with different frequency & amplitude
@@ -273,15 +273,15 @@ export class RunningAnimation extends PlayerAnimation {
 		const t = this.progress * 15 + Math.PI * 0.5;
 
 		// Leg swing with larger amplitude
-		player.skin.leftLeg.rotation.x = Math.cos(t + Math.PI) * 1.3;
-		player.skin.rightLeg.rotation.x = Math.cos(t) * 1.3;
+		player.skin.leftUpperLeg.rotation.x = Math.cos(t + Math.PI) * 1.3;
+		player.skin.rightUpperLeg.rotation.x = Math.cos(t) * 1.3;
 
 		// Arm swing
-		player.skin.leftArm.rotation.x = Math.cos(t) * 1.5;
-		player.skin.rightArm.rotation.x = Math.cos(t + Math.PI) * 1.5;
+		player.skin.leftUpperArm.rotation.x = Math.cos(t) * 1.5;
+		player.skin.rightUpperArm.rotation.x = Math.cos(t + Math.PI) * 1.5;
 		const basicArmRotationZ = Math.PI * 0.1;
-		player.skin.leftArm.rotation.z = Math.cos(t) * 0.1 + basicArmRotationZ;
-		player.skin.rightArm.rotation.z = Math.cos(t + Math.PI) * 0.1 - basicArmRotationZ;
+		player.skin.leftUpperArm.rotation.z = Math.cos(t) * 0.1 + basicArmRotationZ;
+		player.skin.rightUpperArm.rotation.z = Math.cos(t + Math.PI) * 0.1 - basicArmRotationZ;
 
 		// Jumping
 		player.position.y = Math.cos(t * 2);
@@ -317,8 +317,8 @@ export class FlyingAnimation extends PlayerAnimation {
 		player.skin.head.rotation.x = startProgress > 0.5 ? Math.PI / 4 - player.rotation.x : 0;
 
 		const basicArmRotationZ = Math.PI * 0.25 * startProgress;
-		player.skin.leftArm.rotation.z = basicArmRotationZ;
-		player.skin.rightArm.rotation.z = -basicArmRotationZ;
+		player.skin.leftUpperArm.rotation.z = basicArmRotationZ;
+		player.skin.rightUpperArm.rotation.z = -basicArmRotationZ;
 
 		const elytraRotationX = 0.34906584;
 		const elytraRotationZ = Math.PI / 2;
@@ -340,7 +340,7 @@ export class WaveAnimation extends PlayerAnimation {
 	protected animate(player: PlayerObject): void {
 		const t = this.progress * 2 * Math.PI * 0.5;
 
-		const targetArm = this.whichArm === "left" ? player.skin.leftArm : player.skin.rightArm;
+		const targetArm = this.whichArm === "left" ? player.skin.leftUpperArm : player.skin.rightUpperArm;
 		targetArm.rotation.x = 180;
 		targetArm.rotation.z = Math.sin(t) * 0.5;
 	}
@@ -410,17 +410,17 @@ export class CrouchAnimation extends PlayerAnimation {
 			this.isCrouched = false;
 		}
 		player.skin.head.position.y = -3.618325234674 * Math.abs(Math.sin((pr * Math.PI) / 2));
-		player.skin.leftArm.position.z =
+		player.skin.leftUpperArm.position.z =
 			3.618325234674 * Math.abs(Math.sin((pr * Math.PI) / 2)) - 3.4500310377 * Math.abs(Math.sin((pr * Math.PI) / 2));
-		player.skin.rightArm.position.z = player.skin.leftArm.position.z;
-		player.skin.leftArm.rotation.x = 0.410367746202 * Math.abs(Math.sin((pr * Math.PI) / 2));
-		player.skin.rightArm.rotation.x = player.skin.leftArm.rotation.x;
-		player.skin.leftArm.rotation.z = 0.1;
-		player.skin.rightArm.rotation.z = -player.skin.leftArm.rotation.z;
-		player.skin.leftArm.position.y = -2 - 2.53943318 * Math.abs(Math.sin((pr * Math.PI) / 2));
-		player.skin.rightArm.position.y = player.skin.leftArm.position.y;
-		player.skin.rightLeg.position.z = -3.4500310377 * Math.abs(Math.sin((pr * Math.PI) / 2));
-		player.skin.leftLeg.position.z = player.skin.rightLeg.position.z;
+		player.skin.rightUpperArm.position.z = player.skin.leftUpperArm.position.z;
+		player.skin.leftUpperArm.rotation.x = 0.410367746202 * Math.abs(Math.sin((pr * Math.PI) / 2));
+		player.skin.rightUpperArm.rotation.x = player.skin.leftUpperArm.rotation.x;
+		player.skin.leftUpperArm.rotation.z = 0.1;
+		player.skin.rightUpperArm.rotation.z = -player.skin.leftUpperArm.rotation.z;
+		player.skin.leftUpperArm.position.y = -2 - 2.53943318 * Math.abs(Math.sin((pr * Math.PI) / 2));
+		player.skin.rightUpperArm.position.y = player.skin.leftUpperArm.position.y;
+		player.skin.rightUpperLeg.position.z = -3.4500310377 * Math.abs(Math.sin((pr * Math.PI) / 2));
+		player.skin.leftUpperLeg.position.z = player.skin.rightUpperLeg.position.z;
 		if (this.isRunningHitAnimation) {
 			const pr2 = this.progress;
 			let t = (this.progress * 18 * this.hitAnimationSpeed) / this.speed;
@@ -430,16 +430,16 @@ export class CrouchAnimation extends PlayerAnimation {
 			}
 
 			const isCrouching = Math.abs(Math.sin((pr2 * Math.PI) / 2)) === 1;
-			player.skin.rightArm.rotation.x =
+			player.skin.rightUpperArm.rotation.x =
 				-0.4537860552 + 2 * Math.sin(t + Math.PI) * 0.3 - (isCrouching ? 0.4537860552 : 0);
 			const basicArmRotationZ = 0.01 * Math.PI + 0.06;
-			player.skin.rightArm.rotation.z = -Math.cos(t) * 0.403 + basicArmRotationZ;
+			player.skin.rightUpperArm.rotation.z = -Math.cos(t) * 0.403 + basicArmRotationZ;
 			player.skin.body.rotation.y = -Math.cos(t) * 0.06;
-			player.skin.leftArm.rotation.x = Math.sin(t + Math.PI) * 0.077 + (isCrouching ? 0.47 : 0);
-			player.skin.leftArm.rotation.z = -Math.cos(t) * 0.015 + 0.13 - (!isCrouching ? 0.05 : 0);
+			player.skin.leftUpperArm.rotation.x = Math.sin(t + Math.PI) * 0.077 + (isCrouching ? 0.47 : 0);
+			player.skin.leftUpperArm.rotation.z = -Math.cos(t) * 0.015 + 0.13 - (!isCrouching ? 0.05 : 0);
 			if (!isCrouching) {
-				player.skin.leftArm.position.z = Math.cos(t) * 0.3;
-				player.skin.leftArm.position.x = 5 - Math.cos(t) * 0.05;
+				player.skin.leftUpperArm.position.z = Math.cos(t) * 0.3;
+				player.skin.leftUpperArm.position.x = 5 - Math.cos(t) * 0.05;
 			}
 		}
 	}
@@ -447,14 +447,14 @@ export class CrouchAnimation extends PlayerAnimation {
 export class HitAnimation extends PlayerAnimation {
 	protected animate(player: PlayerObject): void {
 		const t = this.progress * 18;
-		player.skin.rightArm.rotation.x = -0.4537860552 * 2 + 2 * Math.sin(t + Math.PI) * 0.3;
+		player.skin.rightUpperArm.rotation.x = -0.4537860552 * 2 + 2 * Math.sin(t + Math.PI) * 0.3;
 		const basicArmRotationZ = 0.01 * Math.PI + 0.06;
-		player.skin.rightArm.rotation.z = -Math.cos(t) * 0.403 + basicArmRotationZ;
+		player.skin.rightUpperArm.rotation.z = -Math.cos(t) * 0.403 + basicArmRotationZ;
 		player.skin.body.rotation.y = -Math.cos(t) * 0.06;
-		player.skin.leftArm.rotation.x = Math.sin(t + Math.PI) * 0.077;
-		player.skin.leftArm.rotation.z = -Math.cos(t) * 0.015 + 0.13 - 0.05;
-		player.skin.leftArm.position.z = Math.cos(t) * 0.3;
-		player.skin.leftArm.position.x = 5 - Math.cos(t) * 0.05;
+		player.skin.leftUpperArm.rotation.x = Math.sin(t + Math.PI) * 0.077;
+		player.skin.leftUpperArm.rotation.z = -Math.cos(t) * 0.015 + 0.13 - 0.05;
+		player.skin.leftUpperArm.position.z = Math.cos(t) * 0.3;
+		player.skin.leftUpperArm.position.x = 5 - Math.cos(t) * 0.05;
 	}
 }
 
@@ -495,32 +495,32 @@ export class BendAnimation extends PlayerAnimation {
 		const arm = s * this.armBend;
 		const leg = s * this.legBend;
 
-		// Bend arms across shoulder, elbow and wrist bones
+		// Bend arms across shoulder, elbow and lower arm bones
 		const armUpper = 5;
 		const armLower = 5;
 		const armShoulderRatio = armLower / (armUpper + armLower);
 		const armElbowRatio = armUpper / (armUpper + armLower);
-		player.skin.leftArm.rotation.x = arm * armShoulderRatio;
-		player.skin.rightArm.rotation.x = arm * armShoulderRatio;
+		player.skin.leftUpperArm.rotation.x = arm * armShoulderRatio;
+		player.skin.rightUpperArm.rotation.x = arm * armShoulderRatio;
 		const elbow = arm * armElbowRatio * 0.6;
-		const wrist = arm * armElbowRatio * 0.4;
-		player.skin.leftArmElbow.rotation.x = elbow;
-		player.skin.leftArmWrist.rotation.x = wrist;
-		player.skin.rightArmElbow.rotation.x = elbow;
-		player.skin.rightArmWrist.rotation.x = wrist;
+		const lower = arm * armElbowRatio * 0.4;
+		player.skin.leftElbow.rotation.x = elbow;
+		player.skin.leftLowerArm.rotation.x = lower;
+		player.skin.rightElbow.rotation.x = elbow;
+		player.skin.rightLowerArm.rotation.x = lower;
 
-		// Bend legs across hip, knee and ankle bones
+		// Bend legs across hip, knee and lower leg bones
 		const legUpper = 5;
 		const legLower = 5;
 		const legHipRatio = legLower / (legUpper + legLower);
 		const legKneeRatio = legUpper / (legUpper + legLower);
-		player.skin.leftLeg.rotation.x = -leg * legHipRatio;
-		player.skin.rightLeg.rotation.x = -leg * legHipRatio;
+		player.skin.leftUpperLeg.rotation.x = -leg * legHipRatio;
+		player.skin.rightUpperLeg.rotation.x = -leg * legHipRatio;
 		const knee = -leg * legKneeRatio * 0.6;
-		const ankle = -leg * legKneeRatio * 0.4;
-		player.skin.leftLegKnee.rotation.x = knee;
-		player.skin.leftLegAnkle.rotation.x = ankle;
-		player.skin.rightLegKnee.rotation.x = knee;
-		player.skin.rightLegAnkle.rotation.x = ankle;
+		const lowerLeg = -leg * legKneeRatio * 0.4;
+		player.skin.leftKnee.rotation.x = knee;
+		player.skin.leftLowerLeg.rotation.x = lowerLeg;
+		player.skin.rightKnee.rotation.x = knee;
+		player.skin.rightLowerLeg.rotation.x = lowerLeg;
 	}
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -82,31 +82,30 @@ export class BodyPart extends Group {
 
 /**
  * Represents a Minecraft player skin with individually accessible body parts
- * and joints. Elbows, knees and their lower limbs are exposed for animation
- * or inverse kinematics through the following pivots:
- * - `rightArmElbow`, `leftArmElbow`, `rightLegKnee`, `leftLegKnee`
- * - `rightArmWrist`, `leftArmWrist`, `rightLegAnkle`, `leftLegAnkle`
+ * and joints. Each limb is composed of 4-unit segments that are chained by
+ * an offset of `-4` on the Y axis. Exposed pivots include the elbows and knees
+ * via:
+ * - `rightElbow`, `leftElbow`, `rightKnee`, `leftKnee`
+ *
+ * This naming scheme mirrors the limb layout (upper & lower segments) to
+ * reduce alignment mistakes when building or animating custom models.
  */
 export class SkinObject extends Group {
 	// body parts
 	readonly head: BodyPart;
 	readonly body: BodyPart;
-	readonly rightArm: BodyPart;
-	readonly leftArm: BodyPart;
-	readonly rightLeg: BodyPart;
-	readonly leftLeg: BodyPart;
-	readonly rightHand: BodyPart;
-	readonly leftHand: BodyPart;
-	readonly rightFoot: BodyPart;
-	readonly leftFoot: BodyPart;
-	readonly rightArmElbow: Group;
-	readonly leftArmElbow: Group;
-	readonly rightArmWrist: Group;
-	readonly leftArmWrist: Group;
-	readonly rightLegKnee: Group;
-	readonly leftLegKnee: Group;
-	readonly rightLegAnkle: Group;
-	readonly leftLegAnkle: Group;
+	readonly rightUpperArm: BodyPart;
+	readonly leftUpperArm: BodyPart;
+	readonly rightUpperLeg: BodyPart;
+	readonly leftUpperLeg: BodyPart;
+	readonly rightLowerArm: BodyPart;
+	readonly leftLowerArm: BodyPart;
+	readonly rightLowerLeg: BodyPart;
+	readonly leftLowerLeg: BodyPart;
+	readonly rightElbow: Group;
+	readonly leftElbow: Group;
+	readonly rightKnee: Group;
+	readonly leftKnee: Group;
 
 	private modelListeners: Array<() => void> = []; // called when model(slim property) is changed
 	private slim = false;
@@ -174,313 +173,309 @@ export class SkinObject extends Group {
 		const rightUpperArmBox = new BoxGeometry();
 		const rightUpperArmMesh = new Mesh(rightUpperArmBox, this.layer1MaterialBiased);
 		rightUpperArmMesh.position.y = -2;
-		const rightMidArmBox = new BoxGeometry();
-		const rightMidArmMesh = new Mesh(rightMidArmBox, this.layer1MaterialBiased);
-		rightMidArmMesh.position.y = -2;
-		const rightLowerArmBox = new BoxGeometry();
-		const rightLowerArmMesh = new Mesh(rightLowerArmBox, this.layer1MaterialBiased);
-		rightLowerArmMesh.position.y = -2;
+		const rightForearmUpperBox = new BoxGeometry();
+		const rightForearmUpperMesh = new Mesh(rightForearmUpperBox, this.layer1MaterialBiased);
+		rightForearmUpperMesh.position.y = -2;
+		const rightForearmLowerBox = new BoxGeometry();
+		const rightForearmLowerMesh = new Mesh(rightForearmLowerBox, this.layer1MaterialBiased);
+		rightForearmLowerMesh.position.y = -2;
 		this.modelListeners.push(() => {
 			rightUpperArmMesh.scale.x = this.slim ? 3 : 4;
 			rightUpperArmMesh.scale.y = 4;
 			rightUpperArmMesh.scale.z = 4;
 			setSkinUVs(rightUpperArmBox, 40, 16, this.slim ? 3 : 4, 4, 4);
-			rightMidArmMesh.scale.x = this.slim ? 3 : 4;
-			rightMidArmMesh.scale.y = 4;
-			rightMidArmMesh.scale.z = 4;
-			setSkinUVs(rightMidArmBox, 40, 20, this.slim ? 3 : 4, 4, 4);
-			rightLowerArmMesh.scale.x = this.slim ? 3 : 4;
-			rightLowerArmMesh.scale.y = 4;
-			rightLowerArmMesh.scale.z = 4;
-			setSkinUVs(rightLowerArmBox, 40, 24, this.slim ? 3 : 4, 4, 4);
+			rightForearmUpperMesh.scale.x = this.slim ? 3 : 4;
+			rightForearmUpperMesh.scale.y = 4;
+			rightForearmUpperMesh.scale.z = 4;
+			setSkinUVs(rightForearmUpperBox, 40, 20, this.slim ? 3 : 4, 4, 4);
+			rightForearmLowerMesh.scale.x = this.slim ? 3 : 4;
+			rightForearmLowerMesh.scale.y = 4;
+			rightForearmLowerMesh.scale.z = 4;
+			setSkinUVs(rightForearmLowerBox, 40, 24, this.slim ? 3 : 4, 4, 4);
 		});
 
 		const rightUpperArm2Box = new BoxGeometry();
 		const rightUpperArm2Mesh = new Mesh(rightUpperArm2Box, this.layer2MaterialBiased);
 		rightUpperArm2Mesh.position.y = -2;
-		const rightMidArm2Box = new BoxGeometry();
-		const rightMidArm2Mesh = new Mesh(rightMidArm2Box, this.layer2MaterialBiased);
-		rightMidArm2Mesh.position.y = -2;
-		const rightLowerArm2Box = new BoxGeometry();
-		const rightLowerArm2Mesh = new Mesh(rightLowerArm2Box, this.layer2MaterialBiased);
-		rightLowerArm2Mesh.position.y = -2;
+		const rightForearmUpper2Box = new BoxGeometry();
+		const rightForearmUpper2Mesh = new Mesh(rightForearmUpper2Box, this.layer2MaterialBiased);
+		rightForearmUpper2Mesh.position.y = -2;
+		const rightForearmLower2Box = new BoxGeometry();
+		const rightForearmLower2Mesh = new Mesh(rightForearmLower2Box, this.layer2MaterialBiased);
+		rightForearmLower2Mesh.position.y = -2;
 		this.modelListeners.push(() => {
 			const rightArm2Scale = this.slim ? 3.5 : 4.5;
 			rightUpperArm2Mesh.scale.x = rightArm2Scale;
 			rightUpperArm2Mesh.scale.y = 4.5;
 			rightUpperArm2Mesh.scale.z = 4.5;
 			setSkinUVs(rightUpperArm2Box, 40, 32, this.slim ? 3 : 4, 4, 4);
-			rightMidArm2Mesh.scale.x = rightArm2Scale;
-			rightMidArm2Mesh.scale.y = 4.5;
-			rightMidArm2Mesh.scale.z = 4.5;
-			setSkinUVs(rightMidArm2Box, 40, 36, this.slim ? 3 : 4, 4, 4);
-			rightLowerArm2Mesh.scale.x = rightArm2Scale;
-			rightLowerArm2Mesh.scale.y = 4.5;
-			rightLowerArm2Mesh.scale.z = 4.5;
-			setSkinUVs(rightLowerArm2Box, 40, 40, this.slim ? 3 : 4, 4, 4);
+			rightForearmUpper2Mesh.scale.x = rightArm2Scale;
+			rightForearmUpper2Mesh.scale.y = 4.5;
+			rightForearmUpper2Mesh.scale.z = 4.5;
+			setSkinUVs(rightForearmUpper2Box, 40, 36, this.slim ? 3 : 4, 4, 4);
+			rightForearmLower2Mesh.scale.x = rightArm2Scale;
+			rightForearmLower2Mesh.scale.y = 4.5;
+			rightForearmLower2Mesh.scale.z = 4.5;
+			setSkinUVs(rightForearmLower2Box, 40, 40, this.slim ? 3 : 4, 4, 4);
 		});
 
-		const rightArmPivot = new Group();
-		rightArmPivot.add(rightUpperArmMesh, rightUpperArm2Mesh);
+		const rightUpperArmPivot = new Group();
+		rightUpperArmPivot.add(rightUpperArmMesh, rightUpperArm2Mesh);
 		this.modelListeners.push(() => {
-			rightArmPivot.position.x = this.slim ? -0.5 : -1;
+			rightUpperArmPivot.position.x = this.slim ? -0.5 : -1;
 		});
-		rightArmPivot.position.y = -4;
+		rightUpperArmPivot.position.y = -4;
 
 		const rightElbow = new Group();
 		rightElbow.position.y = -4;
-		rightElbow.add(rightMidArmMesh, rightMidArm2Mesh);
-		const rightWrist = new Group();
-		rightWrist.position.y = -4;
-		rightWrist.add(rightLowerArmMesh, rightLowerArm2Mesh);
-		rightElbow.add(rightWrist);
-		rightArmPivot.add(rightElbow);
+		rightElbow.add(rightForearmUpperMesh, rightForearmUpper2Mesh);
+		const rightLowerArmPivot = new Group();
+		rightLowerArmPivot.position.y = -4;
+		rightLowerArmPivot.add(rightForearmLowerMesh, rightForearmLower2Mesh);
+		rightElbow.add(rightLowerArmPivot);
+		rightUpperArmPivot.add(rightElbow);
 
-		const rightHandBox = new BoxGeometry(4, 4, 4);
-		setSkinUVs(rightHandBox, 40, 24, 4, 4, 4);
-		const rightHandMesh = new Mesh(rightHandBox, this.layer1MaterialBiased);
-		rightHandMesh.position.y = -2;
-		const rightHand2Box = new BoxGeometry(4.5, 4.5, 4.5);
-		setSkinUVs(rightHand2Box, 40, 40, 4, 4, 4);
-		const rightHand2Mesh = new Mesh(rightHand2Box, this.layer2MaterialBiased);
-		rightHand2Mesh.position.y = -2;
-		this.rightHand = new BodyPart(rightHandMesh, rightHand2Mesh);
-		this.rightHand.name = "rightHand";
-		rightWrist.add(this.rightHand);
+		const rightLowerArmBox = new BoxGeometry(4, 4, 4);
+		setSkinUVs(rightLowerArmBox, 40, 24, 4, 4, 4);
+		const rightLowerArmMesh = new Mesh(rightLowerArmBox, this.layer1MaterialBiased);
+		rightLowerArmMesh.position.y = -2;
+		const rightLowerArm2Box = new BoxGeometry(4.5, 4.5, 4.5);
+		setSkinUVs(rightLowerArm2Box, 40, 40, 4, 4, 4);
+		const rightLowerArm2Mesh = new Mesh(rightLowerArm2Box, this.layer2MaterialBiased);
+		rightLowerArm2Mesh.position.y = -2;
+		this.rightLowerArm = new BodyPart(rightLowerArmMesh, rightLowerArm2Mesh);
+		this.rightLowerArm.name = "rightLowerArm";
+		rightLowerArmPivot.add(this.rightLowerArm);
 
-		this.rightArmElbow = rightElbow;
-		this.rightArmWrist = rightWrist;
+		this.rightElbow = rightElbow;
 
-		this.rightArm = new BodyPart(rightUpperArmMesh, rightUpperArm2Mesh);
-		this.rightArm.name = "rightArm";
-		this.rightArm.add(rightArmPivot);
-		this.rightArm.position.x = -5;
-		this.rightArm.position.y = -2;
-		this.add(this.rightArm);
+		this.rightUpperArm = new BodyPart(rightUpperArmMesh, rightUpperArm2Mesh);
+		this.rightUpperArm.name = "rightUpperArm";
+		this.rightUpperArm.add(rightUpperArmPivot);
+		this.rightUpperArm.position.x = -5;
+		this.rightUpperArm.position.y = -2;
+		this.add(this.rightUpperArm);
 
 		// Left Arm
 		const leftUpperArmBox = new BoxGeometry();
 		const leftUpperArmMesh = new Mesh(leftUpperArmBox, this.layer1MaterialBiased);
 		leftUpperArmMesh.position.y = -2;
-		const leftMidArmBox = new BoxGeometry();
-		const leftMidArmMesh = new Mesh(leftMidArmBox, this.layer1MaterialBiased);
-		leftMidArmMesh.position.y = -2;
-		const leftLowerArmBox = new BoxGeometry();
-		const leftLowerArmMesh = new Mesh(leftLowerArmBox, this.layer1MaterialBiased);
-		leftLowerArmMesh.position.y = -2;
+		const leftForearmUpperBox = new BoxGeometry();
+		const leftForearmUpperMesh = new Mesh(leftForearmUpperBox, this.layer1MaterialBiased);
+		leftForearmUpperMesh.position.y = -2;
+		const leftForearmLowerBox = new BoxGeometry();
+		const leftForearmLowerMesh = new Mesh(leftForearmLowerBox, this.layer1MaterialBiased);
+		leftForearmLowerMesh.position.y = -2;
 		this.modelListeners.push(() => {
 			leftUpperArmMesh.scale.x = this.slim ? 3 : 4;
 			leftUpperArmMesh.scale.y = 4;
 			leftUpperArmMesh.scale.z = 4;
 			setSkinUVs(leftUpperArmBox, 32, 48, this.slim ? 3 : 4, 4, 4);
-			leftMidArmMesh.scale.x = this.slim ? 3 : 4;
-			leftMidArmMesh.scale.y = 4;
-			leftMidArmMesh.scale.z = 4;
-			setSkinUVs(leftMidArmBox, 32, 52, this.slim ? 3 : 4, 4, 4);
-			leftLowerArmMesh.scale.x = this.slim ? 3 : 4;
-			leftLowerArmMesh.scale.y = 4;
-			leftLowerArmMesh.scale.z = 4;
-			setSkinUVs(leftLowerArmBox, 32, 56, this.slim ? 3 : 4, 4, 4);
+			leftForearmUpperMesh.scale.x = this.slim ? 3 : 4;
+			leftForearmUpperMesh.scale.y = 4;
+			leftForearmUpperMesh.scale.z = 4;
+			setSkinUVs(leftForearmUpperBox, 32, 52, this.slim ? 3 : 4, 4, 4);
+			leftForearmLowerMesh.scale.x = this.slim ? 3 : 4;
+			leftForearmLowerMesh.scale.y = 4;
+			leftForearmLowerMesh.scale.z = 4;
+			setSkinUVs(leftForearmLowerBox, 32, 56, this.slim ? 3 : 4, 4, 4);
 		});
 
 		const leftUpperArm2Box = new BoxGeometry();
 		const leftUpperArm2Mesh = new Mesh(leftUpperArm2Box, this.layer2MaterialBiased);
 		leftUpperArm2Mesh.position.y = -2;
-		const leftMidArm2Box = new BoxGeometry();
-		const leftMidArm2Mesh = new Mesh(leftMidArm2Box, this.layer2MaterialBiased);
-		leftMidArm2Mesh.position.y = -2;
-		const leftLowerArm2Box = new BoxGeometry();
-		const leftLowerArm2Mesh = new Mesh(leftLowerArm2Box, this.layer2MaterialBiased);
-		leftLowerArm2Mesh.position.y = -2;
+		const leftForearmUpper2Box = new BoxGeometry();
+		const leftForearmUpper2Mesh = new Mesh(leftForearmUpper2Box, this.layer2MaterialBiased);
+		leftForearmUpper2Mesh.position.y = -2;
+		const leftForearmLower2Box = new BoxGeometry();
+		const leftForearmLower2Mesh = new Mesh(leftForearmLower2Box, this.layer2MaterialBiased);
+		leftForearmLower2Mesh.position.y = -2;
 		this.modelListeners.push(() => {
 			const leftArm2Scale = this.slim ? 3.5 : 4.5;
 			leftUpperArm2Mesh.scale.x = leftArm2Scale;
 			leftUpperArm2Mesh.scale.y = 4.5;
 			leftUpperArm2Mesh.scale.z = 4.5;
 			setSkinUVs(leftUpperArm2Box, 48, 48, this.slim ? 3 : 4, 4, 4);
-			leftMidArm2Mesh.scale.x = leftArm2Scale;
-			leftMidArm2Mesh.scale.y = 4.5;
-			leftMidArm2Mesh.scale.z = 4.5;
-			setSkinUVs(leftMidArm2Box, 48, 52, this.slim ? 3 : 4, 4, 4);
-			leftLowerArm2Mesh.scale.x = leftArm2Scale;
-			leftLowerArm2Mesh.scale.y = 4.5;
-			leftLowerArm2Mesh.scale.z = 4.5;
-			setSkinUVs(leftLowerArm2Box, 48, 56, this.slim ? 3 : 4, 4, 4);
+			leftForearmUpper2Mesh.scale.x = leftArm2Scale;
+			leftForearmUpper2Mesh.scale.y = 4.5;
+			leftForearmUpper2Mesh.scale.z = 4.5;
+			setSkinUVs(leftForearmUpper2Box, 48, 52, this.slim ? 3 : 4, 4, 4);
+			leftForearmLower2Mesh.scale.x = leftArm2Scale;
+			leftForearmLower2Mesh.scale.y = 4.5;
+			leftForearmLower2Mesh.scale.z = 4.5;
+			setSkinUVs(leftForearmLower2Box, 48, 56, this.slim ? 3 : 4, 4, 4);
 		});
 
-		const leftArmPivot = new Group();
-		leftArmPivot.add(leftUpperArmMesh, leftUpperArm2Mesh);
+		const leftUpperArmPivot = new Group();
+		leftUpperArmPivot.add(leftUpperArmMesh, leftUpperArm2Mesh);
 		this.modelListeners.push(() => {
-			leftArmPivot.position.x = this.slim ? 0.5 : 1;
+			leftUpperArmPivot.position.x = this.slim ? 0.5 : 1;
 		});
-		leftArmPivot.position.y = -4;
+		leftUpperArmPivot.position.y = -4;
 
 		const leftElbow = new Group();
 		leftElbow.position.y = -4;
-		leftElbow.add(leftMidArmMesh, leftMidArm2Mesh);
-		const leftWrist = new Group();
-		leftWrist.position.y = -4;
-		leftWrist.add(leftLowerArmMesh, leftLowerArm2Mesh);
-		leftElbow.add(leftWrist);
-		leftArmPivot.add(leftElbow);
+		leftElbow.add(leftForearmUpperMesh, leftForearmUpper2Mesh);
+		const leftLowerArmPivot = new Group();
+		leftLowerArmPivot.position.y = -4;
+		leftLowerArmPivot.add(leftForearmLowerMesh, leftForearmLower2Mesh);
+		leftElbow.add(leftLowerArmPivot);
+		leftUpperArmPivot.add(leftElbow);
 
-		const leftHandBox = new BoxGeometry(4, 4, 4);
-		setSkinUVs(leftHandBox, 32, 56, 4, 4, 4);
-		const leftHandMesh = new Mesh(leftHandBox, this.layer1MaterialBiased);
-		leftHandMesh.position.y = -2;
-		const leftHand2Box = new BoxGeometry(4.5, 4.5, 4.5);
-		setSkinUVs(leftHand2Box, 48, 56, 4, 4, 4);
-		const leftHand2Mesh = new Mesh(leftHand2Box, this.layer2MaterialBiased);
-		leftHand2Mesh.position.y = -2;
-		this.leftHand = new BodyPart(leftHandMesh, leftHand2Mesh);
-		this.leftHand.name = "leftHand";
-		leftWrist.add(this.leftHand);
+		const leftLowerArmBox = new BoxGeometry(4, 4, 4);
+		setSkinUVs(leftLowerArmBox, 32, 56, 4, 4, 4);
+		const leftLowerArmMesh = new Mesh(leftLowerArmBox, this.layer1MaterialBiased);
+		leftLowerArmMesh.position.y = -2;
+		const leftLowerArm2Box = new BoxGeometry(4.5, 4.5, 4.5);
+		setSkinUVs(leftLowerArm2Box, 48, 56, 4, 4, 4);
+		const leftLowerArm2Mesh = new Mesh(leftLowerArm2Box, this.layer2MaterialBiased);
+		leftLowerArm2Mesh.position.y = -2;
+		this.leftLowerArm = new BodyPart(leftLowerArmMesh, leftLowerArm2Mesh);
+		this.leftLowerArm.name = "leftLowerArm";
+		leftLowerArmPivot.add(this.leftLowerArm);
 
-		this.leftArmElbow = leftElbow;
-		this.leftArmWrist = leftWrist;
+		this.leftElbow = leftElbow;
 
-		this.leftArm = new BodyPart(leftUpperArmMesh, leftUpperArm2Mesh);
-		this.leftArm.name = "leftArm";
-		this.leftArm.add(leftArmPivot);
-		this.leftArm.position.x = 5;
-		this.leftArm.position.y = -2;
-		this.add(this.leftArm);
+		this.leftUpperArm = new BodyPart(leftUpperArmMesh, leftUpperArm2Mesh);
+		this.leftUpperArm.name = "leftUpperArm";
+		this.leftUpperArm.add(leftUpperArmPivot);
+		this.leftUpperArm.position.x = 5;
+		this.leftUpperArm.position.y = -2;
+		this.add(this.leftUpperArm);
 
 		// Right Leg
-		const rightLegUpperBox = new BoxGeometry(4, 4, 4);
-		setSkinUVs(rightLegUpperBox, 0, 16, 4, 4, 4);
-		const rightLegUpperMesh = new Mesh(rightLegUpperBox, this.layer1MaterialBiased);
-		rightLegUpperMesh.position.y = -2;
+		const rightUpperLegBox = new BoxGeometry(4, 4, 4);
+		setSkinUVs(rightUpperLegBox, 0, 16, 4, 4, 4);
+		const rightUpperLegMesh = new Mesh(rightUpperLegBox, this.layer1MaterialBiased);
+		rightUpperLegMesh.position.y = -2;
 
-		const rightLegMidBox = new BoxGeometry(4, 4, 4);
-		setSkinUVs(rightLegMidBox, 0, 20, 4, 4, 4);
-		const rightLegMidMesh = new Mesh(rightLegMidBox, this.layer1MaterialBiased);
-		rightLegMidMesh.position.y = -2;
+		const rightLowerLegUpperBox = new BoxGeometry(4, 4, 4);
+		setSkinUVs(rightLowerLegUpperBox, 0, 20, 4, 4, 4);
+		const rightLowerLegUpperMesh = new Mesh(rightLowerLegUpperBox, this.layer1MaterialBiased);
+		rightLowerLegUpperMesh.position.y = -2;
 
-		const rightLegLowerBox = new BoxGeometry(4, 4, 4);
-		setSkinUVs(rightLegLowerBox, 0, 24, 4, 4, 4);
-		const rightLegLowerMesh = new Mesh(rightLegLowerBox, this.layer1MaterialBiased);
-		rightLegLowerMesh.position.y = -2;
+		const rightLowerLegLowerBox = new BoxGeometry(4, 4, 4);
+		setSkinUVs(rightLowerLegLowerBox, 0, 24, 4, 4, 4);
+		const rightLowerLegLowerMesh = new Mesh(rightLowerLegLowerBox, this.layer1MaterialBiased);
+		rightLowerLegLowerMesh.position.y = -2;
 
-		const rightLegUpper2Box = new BoxGeometry(4.5, 4.5, 4.5);
-		setSkinUVs(rightLegUpper2Box, 0, 32, 4, 4, 4);
-		const rightLegUpper2Mesh = new Mesh(rightLegUpper2Box, this.layer2MaterialBiased);
-		rightLegUpper2Mesh.position.y = -2;
+		const rightUpperLeg2Box = new BoxGeometry(4.5, 4.5, 4.5);
+		setSkinUVs(rightUpperLeg2Box, 0, 32, 4, 4, 4);
+		const rightUpperLeg2Mesh = new Mesh(rightUpperLeg2Box, this.layer2MaterialBiased);
+		rightUpperLeg2Mesh.position.y = -2;
 
-		const rightLegMid2Box = new BoxGeometry(4.5, 4.5, 4.5);
-		setSkinUVs(rightLegMid2Box, 0, 36, 4, 4, 4);
-		const rightLegMid2Mesh = new Mesh(rightLegMid2Box, this.layer2MaterialBiased);
-		rightLegMid2Mesh.position.y = -2;
+		const rightLowerLegUpper2Box = new BoxGeometry(4.5, 4.5, 4.5);
+		setSkinUVs(rightLowerLegUpper2Box, 0, 36, 4, 4, 4);
+		const rightLowerLegUpper2Mesh = new Mesh(rightLowerLegUpper2Box, this.layer2MaterialBiased);
+		rightLowerLegUpper2Mesh.position.y = -2;
 
-		const rightLegLower2Box = new BoxGeometry(4.5, 4.5, 4.5);
-		setSkinUVs(rightLegLower2Box, 0, 40, 4, 4, 4);
-		const rightLegLower2Mesh = new Mesh(rightLegLower2Box, this.layer2MaterialBiased);
-		rightLegLower2Mesh.position.y = -2;
+		const rightLowerLegLower2Box = new BoxGeometry(4.5, 4.5, 4.5);
+		setSkinUVs(rightLowerLegLower2Box, 0, 40, 4, 4, 4);
+		const rightLowerLegLower2Mesh = new Mesh(rightLowerLegLower2Box, this.layer2MaterialBiased);
+		rightLowerLegLower2Mesh.position.y = -2;
 
-		const rightLegPivot = new Group();
-		rightLegPivot.position.y = -6;
-		rightLegPivot.add(rightLegUpperMesh, rightLegUpper2Mesh);
+		const rightUpperLegPivot = new Group();
+		rightUpperLegPivot.position.y = -6;
+		rightUpperLegPivot.add(rightUpperLegMesh, rightUpperLeg2Mesh);
 
 		const rightKnee = new Group();
 		rightKnee.position.y = -4;
-		rightKnee.add(rightLegMidMesh, rightLegMid2Mesh);
-		rightLegPivot.add(rightKnee);
+		rightKnee.add(rightLowerLegUpperMesh, rightLowerLegUpper2Mesh);
+		rightUpperLegPivot.add(rightKnee);
 
-		const rightAnkle = new Group();
-		rightAnkle.position.y = -4;
-		rightAnkle.add(rightLegLowerMesh, rightLegLower2Mesh);
-		rightKnee.add(rightAnkle);
+		const rightLowerLegPivot = new Group();
+		rightLowerLegPivot.position.y = -4;
+		rightLowerLegPivot.add(rightLowerLegLowerMesh, rightLowerLegLower2Mesh);
+		rightKnee.add(rightLowerLegPivot);
 
-		const rightFootBox = new BoxGeometry(4, 4, 4);
-		setSkinUVs(rightFootBox, 0, 24, 4, 4, 4);
-		const rightFootMesh = new Mesh(rightFootBox, this.layer1MaterialBiased);
-		rightFootMesh.position.y = -2;
-		const rightFoot2Box = new BoxGeometry(4.5, 4.5, 4.5);
-		setSkinUVs(rightFoot2Box, 0, 40, 4, 4, 4);
-		const rightFoot2Mesh = new Mesh(rightFoot2Box, this.layer2MaterialBiased);
-		rightFoot2Mesh.position.y = -2;
-		this.rightFoot = new BodyPart(rightFootMesh, rightFoot2Mesh);
-		this.rightFoot.name = "rightFoot";
-		rightAnkle.add(this.rightFoot);
+		const rightLowerLegBox = new BoxGeometry(4, 4, 4);
+		setSkinUVs(rightLowerLegBox, 0, 24, 4, 4, 4);
+		const rightLowerLegMesh = new Mesh(rightLowerLegBox, this.layer1MaterialBiased);
+		rightLowerLegMesh.position.y = -2;
+		const rightLowerLeg2Box = new BoxGeometry(4.5, 4.5, 4.5);
+		setSkinUVs(rightLowerLeg2Box, 0, 40, 4, 4, 4);
+		const rightLowerLeg2Mesh = new Mesh(rightLowerLeg2Box, this.layer2MaterialBiased);
+		rightLowerLeg2Mesh.position.y = -2;
+		this.rightLowerLeg = new BodyPart(rightLowerLegMesh, rightLowerLeg2Mesh);
+		this.rightLowerLeg.name = "rightLowerLeg";
+		rightLowerLegPivot.add(this.rightLowerLeg);
 
-		this.rightLegKnee = rightKnee;
-		this.rightLegAnkle = rightAnkle;
+		this.rightKnee = rightKnee;
 
-		this.rightLeg = new BodyPart(rightLegUpperMesh, rightLegUpper2Mesh);
-		this.rightLeg.name = "rightLeg";
-		this.rightLeg.add(rightLegPivot);
-		this.rightLeg.position.x = -1.9;
-		this.rightLeg.position.y = -12;
-		this.rightLeg.position.z = -0.1;
-		this.add(this.rightLeg);
+		this.rightUpperLeg = new BodyPart(rightUpperLegMesh, rightUpperLeg2Mesh);
+		this.rightUpperLeg.name = "rightUpperLeg";
+		this.rightUpperLeg.add(rightUpperLegPivot);
+		this.rightUpperLeg.position.x = -1.9;
+		this.rightUpperLeg.position.y = -12;
+		this.rightUpperLeg.position.z = -0.1;
+		this.add(this.rightUpperLeg);
 
 		// Left Leg
-		const leftLegUpperBox = new BoxGeometry(4, 4, 4);
-		setSkinUVs(leftLegUpperBox, 16, 48, 4, 4, 4);
-		const leftLegUpperMesh = new Mesh(leftLegUpperBox, this.layer1MaterialBiased);
-		leftLegUpperMesh.position.y = -2;
+		const leftUpperLegBox = new BoxGeometry(4, 4, 4);
+		setSkinUVs(leftUpperLegBox, 16, 48, 4, 4, 4);
+		const leftUpperLegMesh = new Mesh(leftUpperLegBox, this.layer1MaterialBiased);
+		leftUpperLegMesh.position.y = -2;
 
-		const leftLegMidBox = new BoxGeometry(4, 4, 4);
-		setSkinUVs(leftLegMidBox, 16, 52, 4, 4, 4);
-		const leftLegMidMesh = new Mesh(leftLegMidBox, this.layer1MaterialBiased);
-		leftLegMidMesh.position.y = -2;
+		const leftLowerLegUpperBox = new BoxGeometry(4, 4, 4);
+		setSkinUVs(leftLowerLegUpperBox, 16, 52, 4, 4, 4);
+		const leftLowerLegUpperMesh = new Mesh(leftLowerLegUpperBox, this.layer1MaterialBiased);
+		leftLowerLegUpperMesh.position.y = -2;
 
-		const leftLegLowerBox = new BoxGeometry(4, 4, 4);
-		setSkinUVs(leftLegLowerBox, 16, 56, 4, 4, 4);
-		const leftLegLowerMesh = new Mesh(leftLegLowerBox, this.layer1MaterialBiased);
-		leftLegLowerMesh.position.y = -2;
+		const leftLowerLegLowerBox = new BoxGeometry(4, 4, 4);
+		setSkinUVs(leftLowerLegLowerBox, 16, 56, 4, 4, 4);
+		const leftLowerLegLowerMesh = new Mesh(leftLowerLegLowerBox, this.layer1MaterialBiased);
+		leftLowerLegLowerMesh.position.y = -2;
 
-		const leftLegUpper2Box = new BoxGeometry(4.5, 4.5, 4.5);
-		setSkinUVs(leftLegUpper2Box, 0, 48, 4, 4, 4);
-		const leftLegUpper2Mesh = new Mesh(leftLegUpper2Box, this.layer2MaterialBiased);
-		leftLegUpper2Mesh.position.y = -2;
+		const leftUpperLeg2Box = new BoxGeometry(4.5, 4.5, 4.5);
+		setSkinUVs(leftUpperLeg2Box, 0, 48, 4, 4, 4);
+		const leftUpperLeg2Mesh = new Mesh(leftUpperLeg2Box, this.layer2MaterialBiased);
+		leftUpperLeg2Mesh.position.y = -2;
 
-		const leftLegMid2Box = new BoxGeometry(4.5, 4.5, 4.5);
-		setSkinUVs(leftLegMid2Box, 0, 52, 4, 4, 4);
-		const leftLegMid2Mesh = new Mesh(leftLegMid2Box, this.layer2MaterialBiased);
-		leftLegMid2Mesh.position.y = -2;
+		const leftLowerLegUpper2Box = new BoxGeometry(4.5, 4.5, 4.5);
+		setSkinUVs(leftLowerLegUpper2Box, 0, 52, 4, 4, 4);
+		const leftLowerLegUpper2Mesh = new Mesh(leftLowerLegUpper2Box, this.layer2MaterialBiased);
+		leftLowerLegUpper2Mesh.position.y = -2;
 
-		const leftLegLower2Box = new BoxGeometry(4.5, 4.5, 4.5);
-		setSkinUVs(leftLegLower2Box, 0, 56, 4, 4, 4);
-		const leftLegLower2Mesh = new Mesh(leftLegLower2Box, this.layer2MaterialBiased);
-		leftLegLower2Mesh.position.y = -2;
+		const leftLowerLegLower2Box = new BoxGeometry(4.5, 4.5, 4.5);
+		setSkinUVs(leftLowerLegLower2Box, 0, 56, 4, 4, 4);
+		const leftLowerLegLower2Mesh = new Mesh(leftLowerLegLower2Box, this.layer2MaterialBiased);
+		leftLowerLegLower2Mesh.position.y = -2;
 
-		const leftLegPivot = new Group();
-		leftLegPivot.position.y = -6;
-		leftLegPivot.add(leftLegUpperMesh, leftLegUpper2Mesh);
+		const leftUpperLegPivot = new Group();
+		leftUpperLegPivot.position.y = -6;
+		leftUpperLegPivot.add(leftUpperLegMesh, leftUpperLeg2Mesh);
 
 		const leftKnee = new Group();
 		leftKnee.position.y = -4;
-		leftKnee.add(leftLegMidMesh, leftLegMid2Mesh);
-		leftLegPivot.add(leftKnee);
+		leftKnee.add(leftLowerLegUpperMesh, leftLowerLegUpper2Mesh);
+		leftUpperLegPivot.add(leftKnee);
 
-		const leftAnkle = new Group();
-		leftAnkle.position.y = -4;
-		leftAnkle.add(leftLegLowerMesh, leftLegLower2Mesh);
-		leftKnee.add(leftAnkle);
+		const leftLowerLegPivot = new Group();
+		leftLowerLegPivot.position.y = -4;
+		leftLowerLegPivot.add(leftLowerLegLowerMesh, leftLowerLegLower2Mesh);
+		leftKnee.add(leftLowerLegPivot);
 
-		const leftFootBox = new BoxGeometry(4, 4, 4);
-		setSkinUVs(leftFootBox, 16, 56, 4, 4, 4);
-		const leftFootMesh = new Mesh(leftFootBox, this.layer1MaterialBiased);
-		leftFootMesh.position.y = -2;
-		const leftFoot2Box = new BoxGeometry(4.5, 4.5, 4.5);
-		setSkinUVs(leftFoot2Box, 0, 56, 4, 4, 4);
-		const leftFoot2Mesh = new Mesh(leftFoot2Box, this.layer2MaterialBiased);
-		leftFoot2Mesh.position.y = -2;
-		this.leftFoot = new BodyPart(leftFootMesh, leftFoot2Mesh);
-		this.leftFoot.name = "leftFoot";
-		leftAnkle.add(this.leftFoot);
+		const leftLowerLegBox = new BoxGeometry(4, 4, 4);
+		setSkinUVs(leftLowerLegBox, 16, 56, 4, 4, 4);
+		const leftLowerLegMesh = new Mesh(leftLowerLegBox, this.layer1MaterialBiased);
+		leftLowerLegMesh.position.y = -2;
+		const leftLowerLeg2Box = new BoxGeometry(4.5, 4.5, 4.5);
+		setSkinUVs(leftLowerLeg2Box, 0, 56, 4, 4, 4);
+		const leftLowerLeg2Mesh = new Mesh(leftLowerLeg2Box, this.layer2MaterialBiased);
+		leftLowerLeg2Mesh.position.y = -2;
+		this.leftLowerLeg = new BodyPart(leftLowerLegMesh, leftLowerLeg2Mesh);
+		this.leftLowerLeg.name = "leftLowerLeg";
+		leftLowerLegPivot.add(this.leftLowerLeg);
 
-		this.leftLegKnee = leftKnee;
-		this.leftLegAnkle = leftAnkle;
+		this.leftKnee = leftKnee;
 
-		this.leftLeg = new BodyPart(leftLegUpperMesh, leftLegUpper2Mesh);
-		this.leftLeg.name = "leftLeg";
-		this.leftLeg.add(leftLegPivot);
-		this.leftLeg.position.x = 1.9;
-		this.leftLeg.position.y = -12;
-		this.leftLeg.position.z = -0.1;
-		this.add(this.leftLeg);
+		this.leftUpperLeg = new BodyPart(leftUpperLegMesh, leftUpperLeg2Mesh);
+		this.leftUpperLeg.name = "leftUpperLeg";
+		this.leftUpperLeg.add(leftUpperLegPivot);
+		this.leftUpperLeg.position.x = 1.9;
+		this.leftUpperLeg.position.y = -12;
+		this.leftUpperLeg.position.z = -0.1;
+		this.add(this.leftUpperLeg);
 
 		this.modelType = "default";
 	}
@@ -534,41 +529,33 @@ export class SkinObject extends Group {
 
 	resetJoints(): void {
 		this.head.rotation.set(0, 0, 0);
-		this.leftArm.rotation.set(0, 0, 0);
-		this.rightArm.rotation.set(0, 0, 0);
-		this.leftLeg.rotation.set(0, 0, 0);
-		this.rightLeg.rotation.set(0, 0, 0);
-		this.rightHand.rotation.set(0, 0, 0);
-		this.leftHand.rotation.set(0, 0, 0);
-		this.rightFoot.rotation.set(0, 0, 0);
-		this.leftFoot.rotation.set(0, 0, 0);
-		this.rightArmElbow.rotation.set(0, 0, 0);
-		this.leftArmElbow.rotation.set(0, 0, 0);
-		this.rightArmWrist.rotation.set(0, 0, 0);
-		this.leftArmWrist.rotation.set(0, 0, 0);
-		this.rightLegKnee.rotation.set(0, 0, 0);
-		this.leftLegKnee.rotation.set(0, 0, 0);
-		this.rightLegAnkle.rotation.set(0, 0, 0);
-		this.leftLegAnkle.rotation.set(0, 0, 0);
-		this.rightArmElbow.position.set(0, -4, 0);
-		this.rightArmWrist.position.set(0, -4, 0);
-		this.leftArmElbow.position.set(0, -4, 0);
-		this.leftArmWrist.position.set(0, -4, 0);
-		this.rightLegKnee.position.set(0, 0, 0);
-		this.rightLegAnkle.position.set(0, -6, 0);
-		this.leftLegKnee.position.set(0, 0, 0);
-		this.leftLegAnkle.position.set(0, -6, 0);
-		this.rightHand.position.set(0, 0, 0);
-		this.leftHand.position.set(0, 0, 0);
-		this.rightFoot.position.set(0, 0, 0);
-		this.leftFoot.position.set(0, 0, 0);
+		this.leftUpperArm.rotation.set(0, 0, 0);
+		this.rightUpperArm.rotation.set(0, 0, 0);
+		this.leftUpperLeg.rotation.set(0, 0, 0);
+		this.rightUpperLeg.rotation.set(0, 0, 0);
+		this.rightLowerArm.rotation.set(0, 0, 0);
+		this.leftLowerArm.rotation.set(0, 0, 0);
+		this.rightLowerLeg.rotation.set(0, 0, 0);
+		this.leftLowerLeg.rotation.set(0, 0, 0);
+		this.rightElbow.rotation.set(0, 0, 0);
+		this.leftElbow.rotation.set(0, 0, 0);
+		this.rightKnee.rotation.set(0, 0, 0);
+		this.leftKnee.rotation.set(0, 0, 0);
+		this.rightElbow.position.set(0, -4, 0);
+		this.leftElbow.position.set(0, -4, 0);
+		this.rightKnee.position.set(0, 0, 0);
+		this.leftKnee.position.set(0, 0, 0);
+		this.rightLowerArm.position.set(0, 0, 0);
+		this.leftLowerArm.position.set(0, 0, 0);
+		this.rightLowerLeg.position.set(0, 0, 0);
+		this.leftLowerLeg.position.set(0, 0, 0);
 		this.body.rotation.set(0, 0, 0);
 		this.head.position.y = 0;
 		this.body.position.set(0, -6, 0);
-		this.rightArm.position.set(-5, -2, 0);
-		this.leftArm.position.set(5, -2, 0);
-		this.rightLeg.position.set(-1.9, -12, -0.1);
-		this.leftLeg.position.set(1.9, -12, -0.1);
+		this.rightUpperArm.position.set(-5, -2, 0);
+		this.leftUpperArm.position.set(5, -2, 0);
+		this.rightUpperLeg.position.set(-1.9, -12, -0.1);
+		this.leftUpperLeg.position.set(1.9, -12, -0.1);
 	}
 }
 


### PR DESCRIPTION
## Summary
- rename arm and leg parts to upper/lower segments and joints
- update animations and examples to use new limb names
- document 4‑unit segment offsets to avoid alignment issues

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68961f86a8888327a20c604cd0a1cf9a