### PR TITLE
Fix knee reset to neutral pose

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -193,7 +193,6 @@ export class SkinObject extends Group {
 			rightForearmLowerMesh.scale.y = 4;
 			rightForearmLowerMesh.scale.z = 4;
 			setSkinUVs(rightForearmLowerBox, 40, 24, this.slim ? 3 : 4, 4, 4);
-
 		});
 
 		const rightUpperArm2Box = new BoxGeometry();
@@ -283,7 +282,6 @@ export class SkinObject extends Group {
 			leftForearmLowerMesh.scale.y = 4;
 			leftForearmLowerMesh.scale.z = 4;
 			setSkinUVs(leftForearmLowerBox, 32, 56, this.slim ? 3 : 4, 4, 4);
-
 		});
 
 		const leftUpperArm2Box = new BoxGeometry();
@@ -364,7 +362,6 @@ export class SkinObject extends Group {
 		setSkinUVs(rightLowerLegLowerBox, 0, 24, 4, 4, 4);
 		const rightLowerLegLowerMesh = new Mesh(rightLowerLegLowerBox, this.layer1MaterialBiased);
 		rightLowerLegLowerMesh.position.y = -2;
-
 
 		const rightUpperLeg2Box = new BoxGeometry(4.5, 4.5, 4.5);
 		setSkinUVs(rightUpperLeg2Box, 0, 32, 4, 4, 4);
@@ -550,8 +547,8 @@ export class SkinObject extends Group {
 		this.leftKnee.rotation.set(0, 0, 0);
 		this.rightElbow.position.set(0, -4, 0);
 		this.leftElbow.position.set(0, -4, 0);
-		this.rightKnee.position.set(0, 0, 0);
-		this.leftKnee.position.set(0, 0, 0);
+		this.rightKnee.position.set(0, -4, 0);
+		this.leftKnee.position.set(0, -4, 0);
 		this.rightLowerArm.position.set(0, 0, 0);
 		this.leftLowerArm.position.set(0, 0, 0);
 		this.rightLowerLeg.position.set(0, 0, 0);


### PR DESCRIPTION
## Summary
- fix knee joints resetting to the wrong position so legs return to neutral pose

## Testing
- `npm test`
- `npm run build:modules`
- `node --input-type=module <<'NODE'\nimport { SkinObject } from './libs/model.js';\nconst skin = new SkinObject();\nskin.rightKnee.position.set(1,2,3);\nskin.leftKnee.position.set(1,2,3);\nskin.resetJoints();\nconsole.log('rightKnee', skin.rightKnee.position.toArray());\nconsole.log('leftKnee', skin.leftKnee.position.toArray());\nNODE`


------
https://chatgpt.com/codex/tasks/task_e_68963914c33083279cfd9acbf5e446a0