### PR TITLE
Ensure layout reflows when animations reset

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1051,6 +1051,9 @@ export class SkinViewer {
 			player.resetJoints();
 			player.position.set(0, 0, 0);
 			player.rotation.set(0, 0, 0);
+			if (this.autoFit) {
+				this.updateLayout();
+			}
 			this.clock.stop();
 			this.clock.autoStart = true;
 		}

--- a/tests/spacing.test.js
+++ b/tests/spacing.test.js
@@ -1,0 +1,31 @@
+import { SkinViewer } from "../libs/viewer.js";
+import { Euler, Vector3 } from "three";
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+test("players retain spacing after animation change", () => {
+	const viewer = Object.create(SkinViewer.prototype);
+	viewer.players = [
+		{ position: new Vector3(), rotation: new Euler(), resetJoints() {} },
+		{ position: new Vector3(), rotation: new Euler(), resetJoints() {} },
+	];
+	viewer.playerSpacing = 20;
+	viewer._autoFit = true;
+	viewer.animations = new Map();
+	viewer.clock = { stop() {}, autoStart: true };
+	viewer.layoutPlayers = SkinViewer.prototype.layoutPlayers;
+	let layoutCalls = 0;
+	viewer.updateLayout = function () {
+		layoutCalls++;
+		this.layoutPlayers();
+	};
+
+	viewer.updateLayout();
+	const before = viewer.players.map(p => p.position.x);
+	layoutCalls = 0;
+	const animation = { progress: 0 };
+	viewer.setAnimation(viewer.players[0], animation);
+	const after = viewer.players.map(p => p.position.x);
+	assert.deepStrictEqual(after, before);
+	assert.equal(layoutCalls, 1);
+});


### PR DESCRIPTION
## Summary
- Update `setAnimation` to reflow layout when auto-fit is enabled
- Add regression test confirming player spacing remains consistent after animation changes

## Testing
- `npm test`
- `node --test tests/spacing.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68963913dc8083278f9ae281977a9cdd