### PR TITLE
Default auto-fit to true and update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,14 @@ canvas: document.getElementById("skin_container"),
 skinViewer.animation = new BendAnimation();
 ```
 
-Enable `autoFit` to automatically spread multiple players and adjust the camera:
+SkinViewer automatically spreads multiple players and adjusts the camera:
 
 You can add more player models to the scene with `addPlayer()`. Pass the returned
 `PlayerObject` to texture-loading methods to control each player independently.
 
-When `autoFit` is enabled (default), the viewer repositions players and adjusts
-the camera after `addPlayer()` or `removePlayer()`. If you disable `autoFit`,
-call `updateLayout()` whenever players are added or removed to keep them
-centered.
+By default, the viewer repositions players and adjusts the camera after
+`addPlayer()` or `removePlayer()`. If you disable `autoFit`, call
+`updateLayout()` whenever players are added or removed to keep them centered.
 
 ```ts
 import { SkinViewer } from "skinview3d";

--- a/examples/auto-fit.ts
+++ b/examples/auto-fit.ts
@@ -5,7 +5,7 @@ const viewer = new skinview3d.SkinViewer({
 	canvas: document.getElementById("viewer") as HTMLCanvasElement,
 	width: 300,
 	height: 400,
-	autoFit: true,
+	// autoFit is enabled by default so multiple players stay visible
 });
 
 viewer.loadSkin("img/1_8_texturemap_redux.png");

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -251,7 +251,7 @@ export interface SkinViewerOptions {
 	 * Whether to automatically arrange multiple players and adjust the camera
 	 * so that all of them are visible.
 	 *
-	 * @defaultValue `false`
+	 * @defaultValue `true`
 	 */
 	autoFit?: boolean;
 }
@@ -485,7 +485,7 @@ export class SkinViewer {
 		if (options.nameTag !== undefined) {
 			this.nameTag = options.nameTag;
 		}
-		this.autoFit = options.autoFit === true;
+		this.autoFit = options.autoFit !== false;
 		this.camera.position.z = 1;
 		this._zoom = options.zoom === undefined ? 0.9 : options.zoom;
 		this.fov = options.fov === undefined ? 50 : options.fov;


### PR DESCRIPTION
## Summary
- treat undefined `autoFit` option as true so multiple players are centered by default
- clarify default behavior in docs and example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68963916c58c832791d7e1e6e5604290