### PR TITLE
docs: record viewport reset and resource menu notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,7 @@ Following these practices will keep the project healthy, extensible, and bug-fre
 - CCDIKSolver integration relies on existing body part groups as bones. Ensure IK targets are included in the bone selector and keyframes capture all bones in a chain.
 - Arm and leg IK chains must be maintained and exposed in the bone selector to avoid regressions.
 - The timeline viewer displays keyframes per bone row. Avoid reverting to a single-row timeline.
+- Viewport reset must be followed by `updateLayout()` to avoid off-center players.
+- Clearing animations when removing players prevents leaks in the player selection dropdown.
+- The resource menu should debounce file inputs; switching textures mid-load can blank the viewer.
+- See `viewport-player-resource-notes.md` for unresolved issues and reproduction steps.

--- a/README.md
+++ b/README.md
@@ -268,5 +268,9 @@ To load this font, please add the `@font-face` rule to your CSS:
 }
 ```
 
+# Development Notes
+
+See [viewport-player-resource-notes.md](viewport-player-resource-notes.md) for notes on viewport reset, player selection, and the resource menu, including current pitfalls and unresolved issues.
+
 # Build
 `npm run build`

--- a/viewport-player-resource-notes.md
+++ b/viewport-player-resource-notes.md
@@ -1,0 +1,38 @@
+# Viewport Reset, Player Selection, and Resource Menu Notes
+
+This document captures recent changes and lessons learned around viewport resetting, player selection, and the resource menu.
+
+## Viewport Reset
+
+- Resets camera pose and player layout when the viewer size changes.
+- **Pitfall:** Calling `resetCameraPose()` without `updateLayout()` may leave players off-center.
+- **Unresolved Issue:** After removing players and resetting the camera, the view can remain misaligned.
+  - **Steps to Reproduce:**
+    1. Open `examples/index.html`.
+    2. Add a second player.
+    3. Remove the added player.
+    4. Run `resetCameraPose()` in the console.
+    5. Observe the camera offset from the remaining player.
+
+## Player Selection
+
+- Dropdown for choosing which player to control or texture.
+- **Pitfall:** Removing a player without clearing its animation causes animations to leak onto new players.
+- **Unresolved Issue:** Rapidly switching selections may duplicate meshes.
+  - **Steps to Reproduce:**
+    1. Open the multi-player example.
+    2. Quickly switch players using the selection dropdown.
+    3. Duplicate models occasionally appear.
+
+## Resource Menu
+
+- Centralized menu to load skins, capes, and other textures.
+- **Pitfall:** File inputs fire too quickly, leading to stale previews.
+- **Unresolved Issue:** Selecting a new resource before a previous texture finishes loading can leave the viewer blank.
+  - **Steps to Reproduce:**
+    1. Open any example using the resource menu.
+    2. Choose a large texture file.
+    3. Before it loads, select another resource.
+    4. The viewer sometimes displays nothing.
+
+These notes will help future contributors understand the context and avoid repeating past issues.


### PR DESCRIPTION
## Summary
- document viewport reset, player selection, and resource menu behavior
- link development notes from README for easier contributor access
- capture known pitfalls and unresolved issues with repro steps

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689640feaa58832786331be6428e75dd