### PR TITLE
Add player selector for targeting example models

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Three.js powered Minecraft skin viewer.
 The demo includes a **Reset All** button that returns the camera to its default
 pose and resets orbit controls after you rotate or zoom the view.
 
+Use the **Player** selector to choose which model receives loaded skins, capes, and animations when multiple players are displayed.
+
 Each texture option (`skin`, `cape`, `ears`, `background`, `panorama`, etc.)
 accepts a URL string, an existing `HTMLImageElement`/`HTMLCanvasElement`, or a
 user-uploaded `File`/`Blob` object.

--- a/examples/index.html
+++ b/examples/index.html
@@ -83,9 +83,14 @@
 			<button id="remove_model" type="button" class="control">Remove Model</button>
 			<button id="change_positioning" type="button" class="control">Change Positioning</button>
 			<button id="toggle_position_controller" type="button" class="control">Toggle Position Controller</button>
+			<label class="control"
+				>Player:
+				<select id="player_selector"></select
+			></label>
 			<label class="control"><input id="auto_fit" type="checkbox" checked /> Auto-fit players</label>
 			<p class="control">
-				Click a player in the canvas to select it for editing. The selected model is highlighted with a green outline.
+				Choose a player from the dropdown or click a model in the canvas to select it for editing. The selected model is
+				highlighted with a green outline.
 			</p>
 			<div id="extra_player_controls" class="control-section"></div>
 

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -72,6 +72,7 @@ const pointer = new Vector2();
 const extraPlayerControls: HTMLElement[] = [];
 let canvasWidth: HTMLInputElement | null = null;
 let canvasHeight: HTMLInputElement | null = null;
+let playerSelector: HTMLSelectElement | null = null;
 const spacingOptions = [20, 40, 60];
 let spacingIndex = 0;
 
@@ -270,6 +271,15 @@ function updateViewportSize(): void {
 		for (const el of backEquipmentRadios) {
 			el.checked = selectedPlayer.backEquipment === el.value;
 		}
+
+		if (playerSelector) {
+			if (selectedPlayer === skinViewer.playerObject) {
+				playerSelector.value = "0";
+			} else {
+				const idx = extraPlayers.indexOf(selectedPlayer);
+				playerSelector.value = idx >= 0 ? String(idx + 1) : "0";
+			}
+		}
 	}
 
 	function handlePlayerClick(event: MouseEvent): void {
@@ -296,6 +306,13 @@ function updateViewportSize(): void {
 function addModel(): void {
 	const player = skinViewer.addPlayer();
 	extraPlayers.push(player);
+	if (playerSelector) {
+		const opt = document.createElement("option");
+		const idx = extraPlayers.length;
+		opt.value = String(idx);
+		opt.textContent = `Player ${idx + 1}`;
+		playerSelector.appendChild(opt);
+	}
 	const anim = new skinview3d.IdleAnimation();
 	skinViewer.setAnimation(player, anim);
 	const index = extraPlayers.length - 1;
@@ -404,6 +421,7 @@ function removeModel(): void {
 		if (selectedPlayer === player) {
 			selectPlayer(null);
 		}
+		playerSelector?.lastElementChild?.remove();
 	}
 	const control = extraPlayerControls.pop();
 	control?.remove();
@@ -725,6 +743,7 @@ function initializeControls(): void {
 	const zoom = document.getElementById("zoom") as HTMLInputElement;
 	const globalLight = document.getElementById("global_light") as HTMLInputElement;
 	const cameraLight = document.getElementById("camera_light") as HTMLInputElement;
+	playerSelector = document.getElementById("player_selector") as HTMLSelectElement;
 	const animationPauseResume = document.getElementById("animation_pause_resume");
 	const editorPlayPause = document.getElementById("editor_play_pause");
 	const highlightJoints = document.getElementById("highlight_joints") as HTMLInputElement;
@@ -761,6 +780,12 @@ function initializeControls(): void {
 	const addHittingAnimation = document.getElementById("add_hitting_animation") as HTMLInputElement;
 
 	uploadStatusEl = document.getElementById("upload_status");
+
+	playerSelector?.addEventListener("change", () => {
+		const idx = Number(playerSelector.value);
+		const player = idx === 0 ? skinViewer.playerObject : extraPlayers[idx - 1];
+		selectPlayer(player ?? null);
+	});
 
 	canvasWidth?.addEventListener("change", e => {
 		const target = e.target as HTMLInputElement;
@@ -1071,6 +1096,15 @@ function initializeViewer(): void {
 	skinViewer = new skinview3d.SkinViewer({
 		canvas: skinContainer,
 	});
+	playerSelector = document.getElementById("player_selector") as HTMLSelectElement;
+	if (playerSelector) {
+		playerSelector.innerHTML = "";
+		const opt = document.createElement("option");
+		opt.value = "0";
+		opt.textContent = "Player 1";
+		playerSelector.appendChild(opt);
+		playerSelector.value = "0";
+	}
 
 	selectPlayer(null);
 


### PR DESCRIPTION
## Summary
- add player selector dropdown to example controls
- sync selection with newly added and removed models
- document how to use the selector

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689650818ca08327a6a2ee62cb831e82