### PR TITLE
fix: clear player resources on removal

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -400,9 +400,17 @@ function addModel(): void {
 function removeModel(): void {
 	const player = extraPlayers.pop();
 	if (player) {
+		skinViewer.setAnimation(player, null);
+		void skinViewer.loadSkin(null, {}, player);
+		void skinViewer.loadCape(null, {}, player);
+		void skinViewer.loadEars(null, {}, player);
 		skinViewer.removePlayer(player);
 		if (selectedPlayer === player) {
 			selectPlayer(null);
+		}
+		const selector = document.getElementById("player_selector") as HTMLSelectElement | null;
+		if (selector && selector.options.length > 0) {
+			selector.remove(selector.options.length - 1);
 		}
 	}
 	const control = extraPlayerControls.pop();

--- a/viewport-player-resource-notes.md
+++ b/viewport-player-resource-notes.md
@@ -18,6 +18,7 @@ This document captures recent changes and lessons learned around viewport resett
 
 - Dropdown for choosing which player to control or texture.
 - **Pitfall:** Removing a player without clearing its animation causes animations to leak onto new players.
+- **Fix:** `removeModel()` clears animations and textures and removes the player's option from the selector to prevent leaks.
 - **Unresolved Issue:** Rapidly switching selections may duplicate meshes.
   - **Steps to Reproduce:**
     1. Open the multi-player example.


### PR DESCRIPTION
## Summary
- clear animations and textures before removing extra players
- drop player option from selector to avoid lingering references
- document the fix to prevent player resource leaks

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689650834d9c8327a32a9a0fca8880af