### PR TITLE
feat: style player resource menu and close on outside click

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -331,7 +331,14 @@ function createPlayerResourceMenu(player: skinview3d.PlayerObject, index: number
 	div.appendChild(uploadBtn);
 
 	const menu = document.createElement("ul");
-	menu.classList.add("hidden");
+	menu.classList.add("resource-menu", "hidden");
+
+	function handleDocumentClick(event: MouseEvent): void {
+		if (!menu.contains(event.target as Node) && event.target !== uploadBtn) {
+			menu.classList.add("hidden");
+			document.removeEventListener("click", handleDocumentClick);
+		}
+	}
 
 	function createMenuItem(label: string, accept: string, load: (file: File) => void | Promise<void>): void {
 		const input = document.createElement("input");
@@ -345,6 +352,7 @@ function createPlayerResourceMenu(player: skinview3d.PlayerObject, index: number
 				await load(file);
 			}
 			menu.classList.add("hidden");
+			document.removeEventListener("click", handleDocumentClick);
 		});
 
 		const item = document.createElement("li");
@@ -371,8 +379,14 @@ function createPlayerResourceMenu(player: skinview3d.PlayerObject, index: number
 	});
 
 	div.appendChild(menu);
-	uploadBtn.addEventListener("click", () => {
+	uploadBtn.addEventListener("click", event => {
+		event.stopPropagation();
 		menu.classList.toggle("hidden");
+		if (menu.classList.contains("hidden")) {
+			document.removeEventListener("click", handleDocumentClick);
+		} else {
+			document.addEventListener("click", handleDocumentClick);
+		}
 	});
 
 	return div;

--- a/examples/style.css
+++ b/examples/style.css
@@ -116,6 +116,23 @@ label {
 	padding-left: 20px;
 }
 
+.control-section .resource-menu {
+	list-style: none;
+	margin: 4px 0 0 0;
+	padding: 0;
+	background: #fff;
+	border: 1px solid #ccc;
+}
+
+.control-section .resource-menu li {
+	padding: 4px 8px;
+	cursor: pointer;
+}
+
+.control-section .resource-menu li:hover {
+	background: #eee;
+}
+
 .hidden {
 	display: none;
 }


### PR DESCRIPTION
## Summary
- style player resource menu list items with background, border, and hover states
- close resource menu when clicking outside via a document-level listener

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68965ddb15c48327b22496d98fe716ab