### PR TITLE
fix(examples): remove duplicate transform mode selector

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -144,13 +144,6 @@
 							<option value="translate">Translate</option>
 						</select>
 					</label>
-					<label class="control">
-						Mode:
-						<select id="transform_mode">
-							<option value="rotate">Rotate</option>
-							<option value="translate">Translate</option>
-						</select>
-					</label>
 					<div id="timeline"></div>
 					<button id="add_keyframe" type="button" class="control">Add Keyframe</button>
 					<button id="download_json" type="button" class="control">Download JSON</button>


### PR DESCRIPTION
## Summary
- remove duplicate transform mode selector in example

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68965ddbf11483278f51c17440a24816