### PR TITLE
Remove default player resource menu from examples

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -1091,13 +1091,6 @@ function initializeViewer(): void {
 
 	selectPlayer(null);
 
-	const controlsContainer = document.getElementById("extra_player_controls");
-	if (controlsContainer) {
-		const control = createPlayerResourceMenu(skinViewer.playerObject, 1);
-		controlsContainer.appendChild(control);
-		extraPlayerControls.push(control);
-	}
-
 	canvasWidth = document.getElementById("canvas_width") as HTMLInputElement;
 	canvasHeight = document.getElementById("canvas_height") as HTMLInputElement;
 	const fov = document.getElementById("fov") as HTMLInputElement;


### PR DESCRIPTION
## Summary
- Drop the automatic resource menu for Player 1 in examples
- Keep resource menu creation for additional players via `addModel`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68965ddfc56883279668be67f01654d7