### PR TITLE
docs: remove stability guidelines from AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,11 +35,6 @@ Welcome to the SkinView3D project. These guidelines help contributors build the 
 - Communicate design decisions and trade-offs in pull request descriptions.
 - Respond to review feedback promptly and respectfully.
 
-## Stability & Rollback Guidelines
-- Use `git reset --hard <hash>` to revert to a known-good commit when necessary.
-- Keep work on separate branches and open pull requests so CI verifies changes before merging.
-- Tag stable releases to mark rollback points and aid consumers.
-
 Following these practices will keep the project healthy, extensible, and bug-free. Happy hacking!
 
 ## Development Insights


### PR DESCRIPTION
## Summary
- revert AGENTS instructions to older version without Stability & Rollback Guidelines section

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68969bed79908327ab7699a5f1add2ce