### PR TITLE
chore: remove resource menu styles

### DIFF
--- a/examples/style.css
+++ b/examples/style.css
@@ -116,23 +116,6 @@ label {
 	padding-left: 20px;
 }
 
-.control-section .resource-menu {
-	list-style: none;
-	margin: 4px 0 0 0;
-	padding: 0;
-	background: #fff;
-	border: 1px solid #ccc;
-}
-
-.control-section .resource-menu li {
-	padding: 4px 8px;
-	cursor: pointer;
-}
-
-.control-section .resource-menu li:hover {
-	background: #eee;
-}
-
 .hidden {
 	display: none;
 }


### PR DESCRIPTION
## Summary
- remove obsolete resource menu and hover styling from example CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68969beb33788327991fcf6310390fae