### PR TITLE
feat(example): export joint coordinates

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -83,6 +83,7 @@
 			<button id="remove_model" type="button" class="control">Remove Model</button>
 			<button id="change_positioning" type="button" class="control">Change Positioning</button>
 			<button id="toggle_position_controller" type="button" class="control">Toggle Position Controller</button>
+			<button id="export_joint_coordinates" type="button" class="control">Export Joint Coordinates</button>
 			<label class="control"
 				>Player:
 				<select id="player_selector"></select

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -847,7 +847,7 @@ function initializeControls(): void {
 		});
 	}
 
-	const defaultRadio = document.getElementById("animation_bend") as HTMLInputElement;
+	const defaultRadio = document.getElementById("animation_jump") as HTMLInputElement;
 	if (defaultRadio) {
 		defaultRadio.checked = true;
 		defaultRadio.dispatchEvent(new Event("change"));
@@ -1047,6 +1047,18 @@ function initializeControls(): void {
 	const togglePositionBtn = document.getElementById("toggle_position_controller");
 	togglePositionBtn?.addEventListener("click", togglePositionController);
 
+	const exportJointBtn = document.getElementById("export_joint_coordinates");
+	exportJointBtn?.addEventListener("click", () => {
+		const data = (skinViewer as any).exportJointCoordinates();
+		const blob = new Blob([data], { type: "text/plain" });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = "joint-coordinates.txt";
+		a.click();
+		URL.revokeObjectURL(url);
+	});
+
 	const nametagText = document.getElementById("nametag_text") as HTMLInputElement;
 	nametagText?.addEventListener("change", reloadNameTag);
 
@@ -1077,6 +1089,7 @@ function initializeViewer(): void {
 	skinViewer = new skinview3d.SkinViewer({
 		canvas: skinContainer,
 	});
+	(skinViewer as any).enableJointControls();
 	playerSelector = document.getElementById("player_selector") as HTMLSelectElement;
 	if (playerSelector) {
 		playerSelector.innerHTML = "";


### PR DESCRIPTION
## Summary
- add Export Joint Coordinates button to example controls
- enable joint controls and export functionality in main example
- default to JumpAnimation for demonstrations

## Testing
- `npm test`
- `npm run build:preview`


------
https://chatgpt.com/codex/tasks/task_e_6899e78b6af48327a4f2dc2bb181f286