### PR TITLE
Remove duplicate transform mode selector in example

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -145,13 +145,6 @@
 							<option value="translate">Translate</option>
 						</select>
 					</label>
-					<label class="control">
-						Mode:
-						<select id="transform_mode">
-							<option value="rotate">Rotate</option>
-							<option value="translate">Translate</option>
-						</select>
-					</label>
 					<div id="timeline"></div>
 					<button id="add_keyframe" type="button" class="control">Add Keyframe</button>
 					<button id="download_json" type="button" class="control">Download JSON</button>


### PR DESCRIPTION
## Summary
- remove duplicate `transform_mode` selector in example page so the animation editor uses a single mode dropdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a33c7b0b48327affcefe60003b511