### PR TITLE
guard example DOM lookups and defer viewer init

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -1093,9 +1093,10 @@ function initializeControls(): void {
 
 function initializeViewer(): void {
 	disposeIK();
-	const skinContainer = document.getElementById("skin_container") as HTMLCanvasElement;
+	const skinContainer = document.getElementById("skin_container") as HTMLCanvasElement | null;
 	if (!skinContainer) {
-		throw new Error("Canvas element not found");
+		console.error("Canvas element not found; viewer not initialized.");
+		return;
 	}
 
 	skinViewer = new skinview3d.SkinViewer({
@@ -1187,15 +1188,23 @@ function initializeViewer(): void {
 	updateViewportSize();
 }
 
-initializeViewer();
-initializeControls();
-setupIK();
-initializeBoneSelector(true);
-document.getElementById("skin_container")?.addEventListener("click", handlePlayerClick);
+window.addEventListener("DOMContentLoaded", () => {
+	initializeViewer();
+	initializeControls();
+	setupIK();
+	initializeBoneSelector(true);
+	const skinContainer = document.getElementById("skin_container");
+	if (skinContainer) {
+		skinContainer.addEventListener("click", handlePlayerClick);
+	} else {
+		console.error("Skin container element not found; click handler not attached.");
+	}
+});
 
 function initializeBoneSelector(useIK = false): void {
-	const selector = document.getElementById("bone_selector") as HTMLSelectElement;
+	const selector = document.getElementById("bone_selector") as HTMLSelectElement | null;
 	if (!selector) {
+		console.error("Bone selector element not found; bone selection disabled.");
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- Defer viewer initialization until DOM ready in `examples/main.ts`
- Log errors when required DOM elements like the viewer canvas or bone selector are missing
- Safely attach click handler only when skin container exists

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4d7f0f6c83279eb93e7ef6865754