### PR TITLE
feat: add play/pause handler for editor animation

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -818,9 +818,15 @@ function initializeControls(): void {
 	});
 
 	editorPlayPause?.addEventListener("click", () => {
-		if (loadedAnimation) {
-			loadedAnimation.paused = !loadedAnimation.paused;
+		const wasPaused = loadedAnimation?.paused ?? true;
+		const anim = buildKeyframeAnimation();
+		if (!anim) {
+			return;
 		}
+		skinViewer.setAnimation(selectedPlayer, anim);
+		loadedAnimation = anim;
+		anim.paused = !wasPaused;
+		(editorPlayPause as HTMLButtonElement).textContent = anim.paused ? "Play" : "Pause";
 	});
 
 	autoRotate?.addEventListener("change", e => {


### PR DESCRIPTION
## Summary
- build and cache keyframe animation from editor on play/pause
- toggle animation paused state and update button label

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a4d81a2308327a5c3d3c84cdac32a