### PR TITLE
Reset skin root translation on joint reset

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -777,6 +777,7 @@ export class PlayerObject extends Group {
 
 	resetJoints(): void {
 		this.skin.resetJoints();
+		this.skin.position.set(0, 8, 0);
 		this.cape.rotation.x = CapeDefaultAngle;
 		this.cape.position.y = 8;
 		this.cape.position.z = -2;

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -33,6 +33,19 @@ test("resetJoints restores default pivots for arms and legs", () => {
 	assert.ok(skin.rightLowerLeg.position.equals(new Vector3(0, 0, 0)));
 	assert.ok(skin.leftElbow.position.equals(new Vector3(0, -4, 0)));
 	assert.ok(skin.rightElbow.position.equals(new Vector3(0, -4, 0)));
-	assert.ok(skin.leftKnee.position.equals(new Vector3(0, -4, 0)));
-	assert.ok(skin.rightKnee.position.equals(new Vector3(0, -4, 0)));
+        assert.ok(skin.leftKnee.position.equals(new Vector3(0, -4, 0)));
+        assert.ok(skin.rightKnee.position.equals(new Vector3(0, -4, 0)));
+});
+
+test("resetJoints restores the skin root translation", () => {
+        const player = new PlayerObject();
+        const skin = player.skin;
+
+        skin.position.set(1, 2, 3);
+        skin.rightUpperArm.position.set(1, 1, 1);
+
+        player.resetJoints();
+
+        assert.ok(skin.rightUpperArm.position.equals(new Vector3(-5, -6, 0)));
+        assert.ok(skin.position.equals(new Vector3(0, 8, 0)));
 });


### PR DESCRIPTION
## Summary
- Restore skin root translation when resetting joints
- Add regression test for skin root translation reset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b57fbc984832793726f7471125079