### PR TITLE
fix: align limb joint offsets with rounded model

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -581,11 +581,16 @@ export class SkinObject extends Group {
 		this.head.position.y = 0;
 		this.body.position.set(0, -6, 0);
 
-		this.rightUpperArm.position.set(-5, -6, 0);
-		this.leftUpperArm.position.set(5, -6, 0);
+		this.rightLowerArm.position.set(0, 0, 0);
+		this.leftLowerArm.position.set(0, 0, 0);
+		this.rightLowerLeg.position.set(0, 0, 0);
+		this.leftLowerLeg.position.set(0, 0, 0);
 
-		this.rightUpperLeg.position.set(-2, -12, 0);
-		this.leftUpperLeg.position.set(2, -12, 0);
+		this.rightUpperArm.position.set(-4.089, 0.6, 0);
+		this.leftUpperArm.position.set(4.085, 0.867, 0);
+
+		this.rightUpperLeg.position.set(-2, -11.4, 0);
+		this.leftUpperLeg.position.set(2, -11.133, 0);
 	}
 }
 

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -3,6 +3,12 @@ import { strict as assert } from "node:assert";
 import { Vector3 } from "three";
 import { PlayerObject } from "../libs/model.js";
 
+function assertWorldPosition(obj, expected) {
+        const actual = new Vector3();
+        obj.getWorldPosition(actual);
+        assert.ok(actual.distanceTo(expected) < 1e-3);
+}
+
 test("resetJoints restores default pivots for arms and legs", () => {
 	const player = new PlayerObject();
 	const skin = player.skin;
@@ -21,20 +27,20 @@ test("resetJoints restores default pivots for arms and legs", () => {
 	skin.leftKnee.position.set(1, 1, 1);
 	skin.rightKnee.position.set(1, 1, 1);
 
-	player.resetJoints();
+        player.resetJoints();
 
-        assert.ok(skin.leftUpperArm.position.equals(new Vector3(5, -6, 0)));
-        assert.ok(skin.rightUpperArm.position.equals(new Vector3(-5, -6, 0)));
-	assert.ok(skin.leftLowerArm.position.equals(new Vector3(0, 0, 0)));
-	assert.ok(skin.rightLowerArm.position.equals(new Vector3(0, 0, 0)));
-	assert.ok(skin.leftUpperLeg.position.equals(new Vector3(2, -12, 0)));
-	assert.ok(skin.rightUpperLeg.position.equals(new Vector3(-2, -12, 0)));
-	assert.ok(skin.leftLowerLeg.position.equals(new Vector3(0, 0, 0)));
-	assert.ok(skin.rightLowerLeg.position.equals(new Vector3(0, 0, 0)));
-	assert.ok(skin.leftElbow.position.equals(new Vector3(0, -4, 0)));
-	assert.ok(skin.rightElbow.position.equals(new Vector3(0, -4, 0)));
-        assert.ok(skin.leftKnee.position.equals(new Vector3(0, -4, 0)));
-        assert.ok(skin.rightKnee.position.equals(new Vector3(0, -4, 0)));
+        assertWorldPosition(skin.leftUpperArm, new Vector3(4.085, 8.867, 0));
+        assertWorldPosition(skin.rightUpperArm, new Vector3(-4.089, 8.6, 0));
+        assertWorldPosition(skin.leftLowerArm, new Vector3(4.085, 0.867, 0));
+        assertWorldPosition(skin.rightLowerArm, new Vector3(-4.089, 0.6, 0));
+        assertWorldPosition(skin.leftUpperLeg, new Vector3(2, -3.133, 0));
+        assertWorldPosition(skin.rightUpperLeg, new Vector3(-2, -3.4, 0));
+        assertWorldPosition(skin.leftLowerLeg, new Vector3(2, -11.133, 0));
+        assertWorldPosition(skin.rightLowerLeg, new Vector3(-2, -11.4, 0));
+        assertWorldPosition(skin.leftElbow, new Vector3(4.085, 4.867, 0));
+        assertWorldPosition(skin.rightElbow, new Vector3(-4.089, 4.6, 0));
+        assertWorldPosition(skin.leftKnee, new Vector3(2, -7.133, 0));
+        assertWorldPosition(skin.rightKnee, new Vector3(-2, -7.4, 0));
 });
 
 test("resetJoints restores the skin root translation", () => {
@@ -46,6 +52,6 @@ test("resetJoints restores the skin root translation", () => {
 
         player.resetJoints();
 
-        assert.ok(skin.rightUpperArm.position.equals(new Vector3(-5, -6, 0)));
+        assertWorldPosition(skin.rightUpperArm, new Vector3(-4.089, 8.6, 0));
         assert.ok(skin.position.equals(new Vector3(0, 8, 0)));
 });


### PR DESCRIPTION
## Summary
- adjust shoulder, elbow, knee, and limb offsets for rounded mesh dimensions
- verify joint world positions in tests via `getWorldPosition`

## Testing
- `node --test tests/model.test.js tests/spacing.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b5b9dfd448327bc23880e653f61e0