### PR TITLE
Initialize PlayerObject joints on construction

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -739,21 +739,15 @@ export class PlayerObject extends Group {
 
 		this.skin = new SkinObject();
 		this.skin.name = "skin";
-		this.skin.position.y = 8;
 		this.add(this.skin);
 
 		this.cape = new CapeObject();
 		this.cape.name = "cape";
-		this.cape.position.y = 8;
-		this.cape.position.z = -2;
-		this.cape.rotation.x = CapeDefaultAngle;
 		this.cape.rotation.y = Math.PI;
 		this.add(this.cape);
 
 		this.elytra = new ElytraObject();
 		this.elytra.name = "elytra";
-		this.elytra.position.y = 8;
-		this.elytra.position.z = -2;
 		this.elytra.visible = false;
 		this.add(this.elytra);
 
@@ -763,6 +757,8 @@ export class PlayerObject extends Group {
 		this.ears.position.z = 2 / 3;
 		this.ears.visible = false;
 		this.skin.head.add(this.ears);
+
+		this.resetJoints();
 	}
 
 	get backEquipment(): BackEquipment | null {

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -9,6 +9,24 @@ function assertWorldPosition(obj, expected) {
         assert.ok(actual.distanceTo(expected) < 1e-3);
 }
 
+test("new players spawn with correct limb placement", () => {
+        const player = new PlayerObject();
+        const skin = player.skin;
+
+        assertWorldPosition(skin.leftUpperArm, new Vector3(4.085, 8.867, 0));
+        assertWorldPosition(skin.rightUpperArm, new Vector3(-4.089, 8.6, 0));
+        assertWorldPosition(skin.leftLowerArm, new Vector3(4.085, 0.867, 0));
+        assertWorldPosition(skin.rightLowerArm, new Vector3(-4.089, 0.6, 0));
+        assertWorldPosition(skin.leftUpperLeg, new Vector3(2, -3.133, 0));
+        assertWorldPosition(skin.rightUpperLeg, new Vector3(-2, -3.4, 0));
+        assertWorldPosition(skin.leftLowerLeg, new Vector3(2, -11.133, 0));
+        assertWorldPosition(skin.rightLowerLeg, new Vector3(-2, -11.4, 0));
+        assertWorldPosition(skin.leftElbow, new Vector3(4.085, 4.867, 0));
+        assertWorldPosition(skin.rightElbow, new Vector3(-4.089, 4.6, 0));
+        assertWorldPosition(skin.leftKnee, new Vector3(2, -7.133, 0));
+        assertWorldPosition(skin.rightKnee, new Vector3(-2, -7.4, 0));
+});
+
 test("resetJoints restores default pivots for arms and legs", () => {
 	const player = new PlayerObject();
 	const skin = player.skin;


### PR DESCRIPTION
## Summary
- call `resetJoints()` in `PlayerObject` constructor and drop redundant position setup
- add regression test ensuring new players spawn with correct limb placement

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b62527a4c8327b98b30e605708513