### PR TITLE
Ensure joints reset when re-selecting animations

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1048,8 +1048,9 @@ export class SkinViewer {
 	}
 
 	setAnimation(player: PlayerObject, animation: PlayerAnimation | null): void {
-		if (this.getAnimation(player) !== animation) {
-			player.resetJoints();
+		const current = this.getAnimation(player);
+		player.resetJoints();
+		if (current !== animation) {
 			player.position.set(0, 0, 0);
 			player.rotation.set(0, 0, 0);
 			if (this.autoFit) {

--- a/tests/animation-reset.test.js
+++ b/tests/animation-reset.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import { strict as assert } from "node:assert";
+import { SkinViewer } from "../libs/viewer.js";
+import { PlayerAnimation } from "../libs/animation.js";
+import { PlayerObject } from "../libs/model.js";
+
+class AnimA extends PlayerAnimation {
+	animate(player) {
+		player.skin.leftUpperArmPivot.rotation.x = 0.5;
+	}
+}
+
+class AnimB extends PlayerAnimation {
+	animate(player) {
+		player.skin.rightUpperArmPivot.rotation.y = 0.5;
+	}
+}
+
+test("setAnimation resets limbs and progress when switching", () => {
+	const viewer = Object.create(SkinViewer.prototype);
+	const player = new PlayerObject();
+	viewer.players = [player];
+	viewer.animations = new Map();
+	viewer.clock = { stop() {}, autoStart: true };
+	viewer._autoFit = false;
+	viewer.updateLayout = () => {};
+
+	const anim1 = new AnimA();
+	anim1.progress = 5;
+	viewer.setAnimation(player, anim1);
+	assert.equal(anim1.progress, 0);
+	anim1.update(player, 1);
+	assert.notEqual(player.skin.leftUpperArmPivot.rotation.x, 0);
+
+	const anim2 = new AnimB();
+	anim2.progress = 5;
+	viewer.setAnimation(player, anim2);
+	assert.equal(anim2.progress, 0);
+
+	const limbs = [
+		player.skin.leftUpperArmPivot,
+		player.skin.rightUpperArmPivot,
+		player.skin.leftLowerArmPivot,
+		player.skin.rightLowerArmPivot,
+		player.skin.leftElbow,
+		player.skin.rightElbow,
+		player.skin.leftUpperLegPivot,
+		player.skin.rightUpperLegPivot,
+		player.skin.leftLowerLegPivot,
+		player.skin.rightLowerLegPivot,
+		player.skin.leftKnee,
+		player.skin.rightKnee,
+	];
+	for (const limb of limbs) {
+		assert.equal(limb.rotation.x, 0);
+		assert.equal(limb.rotation.y, 0);
+		assert.equal(limb.rotation.z, 0);
+	}
+});


### PR DESCRIPTION
## Summary
- Always reset player joints before setting a new animation, even if the instance matches
- Add regression test verifying joint rotations reset and progress starts at 0 when switching animations

## Testing
- `node --test tests/*.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b62539f3c8327977cb21029251e97