### PR TITLE
Split torso into upper and lower segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,5 +281,12 @@ To load this font, please add the `@font-face` rule to your CSS:
 
 See [viewport-player-resource-notes.md](viewport-player-resource-notes.md) for notes on viewport reset, player selection, and the resource menu, including current pitfalls and unresolved issues.
 
+# Migration
+
+The former `body` part has been split into `upperBody` and `lowerBody` segments
+joined by a `waist` pivot. Update any references to `skin.body` to use
+`skin.upperBody`, `skin.lowerBody`, or `skin.waist` depending on the desired
+torso joint.
+
 # Build
 `npm run build`

--- a/examples/index.html
+++ b/examples/index.html
@@ -118,7 +118,8 @@
 						<select id="bone_selector">
 							<option value="playerObject">Player</option>
 							<option value="skin.head">skin.head</option>
-							<option value="skin.body">skin.body</option>
+							<option value="skin.upperBody">skin.upperBody</option>
+							<option value="skin.lowerBody">skin.lowerBody</option>
 							<option value="skin.rightUpperArm">skin.rightUpperArm</option>
 							<option value="skin.rightElbow">skin.rightElbow</option>
 							<option value="skin.rightLowerArm">skin.rightLowerArm</option>
@@ -235,7 +236,8 @@
 						<tr>
 							<th></th>
 							<th>head</th>
-							<th>body</th>
+							<th>upper body</th>
+							<th>lower body</th>
 							<th>right upper arm</th>
 							<th>left upper arm</th>
 							<th>right upper leg</th>
@@ -246,7 +248,8 @@
 						<tr>
 							<th>inner</th>
 							<td><input type="checkbox" data-layer="innerLayer" data-part="head" checked /></td>
-							<td><input type="checkbox" data-layer="innerLayer" data-part="body" checked /></td>
+							<td><input type="checkbox" data-layer="innerLayer" data-part="upperBody" checked /></td>
+							<td><input type="checkbox" data-layer="innerLayer" data-part="lowerBody" checked /></td>
 							<td><input type="checkbox" data-layer="innerLayer" data-part="rightUpperArm" checked /></td>
 							<td><input type="checkbox" data-layer="innerLayer" data-part="leftUpperArm" checked /></td>
 							<td><input type="checkbox" data-layer="innerLayer" data-part="rightUpperLeg" checked /></td>
@@ -255,7 +258,8 @@
 						<tr>
 							<th>outer</th>
 							<td><input type="checkbox" data-layer="outerLayer" data-part="head" checked /></td>
-							<td><input type="checkbox" data-layer="outerLayer" data-part="body" checked /></td>
+							<td><input type="checkbox" data-layer="outerLayer" data-part="upperBody" checked /></td>
+							<td><input type="checkbox" data-layer="outerLayer" data-part="lowerBody" checked /></td>
 							<td><input type="checkbox" data-layer="outerLayer" data-part="rightUpperArm" checked /></td>
 							<td><input type="checkbox" data-layer="outerLayer" data-part="leftUpperArm" checked /></td>
 							<td><input type="checkbox" data-layer="outerLayer" data-part="rightUpperLeg" checked /></td>

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -21,7 +21,8 @@ import { JumpAnimation } from "./jump-animation";
 
 const skinParts = [
 	"head",
-	"body",
+	"upperBody",
+	"lowerBody",
 	"rightUpperArm",
 	"leftUpperArm",
 	"rightUpperLeg",

--- a/src/animation.ts
+++ b/src/animation.ts
@@ -383,10 +383,10 @@ export class CrouchAnimation extends PlayerAnimation {
 		if (!this.showProgress) {
 			pr = Math.floor(pr);
 		}
-		player.skin.body.rotation.x = 0.4537860552 * Math.abs(Math.sin((pr * Math.PI) / 2));
-		player.skin.body.position.z =
+		player.skin.waist.rotation.x = 0.4537860552 * Math.abs(Math.sin((pr * Math.PI) / 2));
+		player.skin.waist.position.z =
 			1.3256181 * Math.abs(Math.sin((pr * Math.PI) / 2)) - 3.4500310377 * Math.abs(Math.sin((pr * Math.PI) / 2));
-		player.skin.body.position.y = -6 - 2.103677462 * Math.abs(Math.sin((pr * Math.PI) / 2));
+		player.skin.waist.position.y = -6 - 2.103677462 * Math.abs(Math.sin((pr * Math.PI) / 2));
 		player.cape.position.y = 8 - 1.851236166577372 * Math.abs(Math.sin((pr * Math.PI) / 2));
 		player.cape.rotation.x = (10.8 * Math.PI) / 180 + 0.294220265771 * Math.abs(Math.sin((pr * Math.PI) / 2));
 		player.cape.position.z =
@@ -434,7 +434,7 @@ export class CrouchAnimation extends PlayerAnimation {
 				-0.4537860552 + 2 * Math.sin(t + Math.PI) * 0.3 - (isCrouching ? 0.4537860552 : 0);
 			const basicArmRotationZ = 0.01 * Math.PI + 0.06;
 			player.skin.rightUpperArm.rotation.z = -Math.cos(t) * 0.403 + basicArmRotationZ;
-			player.skin.body.rotation.y = -Math.cos(t) * 0.06;
+			player.skin.waist.rotation.y = -Math.cos(t) * 0.06;
 			player.skin.leftUpperArm.rotation.x = Math.sin(t + Math.PI) * 0.077 + (isCrouching ? 0.47 : 0);
 			player.skin.leftUpperArm.rotation.z = -Math.cos(t) * 0.015 + 0.13 - (!isCrouching ? 0.05 : 0);
 			if (!isCrouching) {
@@ -450,7 +450,7 @@ export class HitAnimation extends PlayerAnimation {
 		player.skin.rightUpperArm.rotation.x = -0.4537860552 * 2 + 2 * Math.sin(t + Math.PI) * 0.3;
 		const basicArmRotationZ = 0.01 * Math.PI + 0.06;
 		player.skin.rightUpperArm.rotation.z = -Math.cos(t) * 0.403 + basicArmRotationZ;
-		player.skin.body.rotation.y = -Math.cos(t) * 0.06;
+		player.skin.waist.rotation.y = -Math.cos(t) * 0.06;
 		player.skin.leftUpperArm.rotation.x = Math.sin(t + Math.PI) * 0.077;
 		player.skin.leftUpperArm.rotation.z = -Math.cos(t) * 0.015 + 0.13 - 0.05;
 		player.skin.leftUpperArm.position.z = Math.cos(t) * 0.3;

--- a/src/model.ts
+++ b/src/model.ts
@@ -85,7 +85,8 @@ export class BodyPart extends Group {
 export class SkinObject extends Group {
 	// body parts
 	readonly head: BodyPart;
-	readonly body: BodyPart;
+	readonly upperBody: BodyPart;
+	readonly lowerBody: BodyPart;
 	readonly rightUpperArm: BodyPart;
 	readonly leftUpperArm: BodyPart;
 	readonly rightUpperLeg: BodyPart;
@@ -94,6 +95,7 @@ export class SkinObject extends Group {
 	readonly leftLowerArm: BodyPart;
 	readonly rightLowerLeg: BodyPart;
 	readonly leftLowerLeg: BodyPart;
+	readonly waist: Group;
 	readonly rightUpperArmPivot: Group;
 	readonly leftUpperArmPivot: Group;
 	readonly rightLowerArmPivot: Group;
@@ -148,18 +150,40 @@ export class SkinObject extends Group {
 		this.add(this.head);
 
 		// Body
-		const bodyBox = new BoxGeometry(8, 12, 4);
-		setSkinUVs(bodyBox, 16, 16, 8, 12, 4);
-		const bodyMesh = new Mesh(bodyBox, this.layer1Material);
-		const body2Box = new BoxGeometry(8.5, 12.5, 4.5);
-		setSkinUVs(body2Box, 16, 32, 8, 12, 4);
-		const body2Mesh = new Mesh(body2Box, this.layer2Material);
+		const waist = new Group();
+		waist.name = "waist";
+		waist.position.y = -6;
 
-		this.body = new BodyPart(bodyMesh, body2Mesh);
-		this.body.name = "body";
-		this.body.add(bodyMesh, body2Mesh);
-		this.body.position.y = -6;
-		this.add(this.body);
+		const upperBodyBox = new BoxGeometry(8, 6, 4);
+		setSkinUVs(upperBodyBox, 16, 16, 8, 6, 4);
+		const upperBodyMesh = new Mesh(upperBodyBox, this.layer1Material);
+		upperBodyMesh.position.y = 3;
+		const upperBody2Box = new BoxGeometry(8.5, 6.5, 4.5);
+		setSkinUVs(upperBody2Box, 16, 32, 8, 6, 4);
+		const upperBody2Mesh = new Mesh(upperBody2Box, this.layer2Material);
+		upperBody2Mesh.position.y = 3;
+
+		this.upperBody = new BodyPart(upperBodyMesh, upperBody2Mesh);
+		this.upperBody.name = "upperBody";
+		this.upperBody.add(upperBodyMesh, upperBody2Mesh);
+		waist.add(this.upperBody);
+
+		const lowerBodyBox = new BoxGeometry(8, 6, 4);
+		setSkinUVs(lowerBodyBox, 16, 22, 8, 6, 4);
+		const lowerBodyMesh = new Mesh(lowerBodyBox, this.layer1Material);
+		lowerBodyMesh.position.y = -3;
+		const lowerBody2Box = new BoxGeometry(8.5, 6.5, 4.5);
+		setSkinUVs(lowerBody2Box, 16, 38, 8, 6, 4);
+		const lowerBody2Mesh = new Mesh(lowerBody2Box, this.layer2Material);
+		lowerBody2Mesh.position.y = -3;
+
+		this.lowerBody = new BodyPart(lowerBodyMesh, lowerBody2Mesh);
+		this.lowerBody.name = "lowerBody";
+		this.lowerBody.add(lowerBodyMesh, lowerBody2Mesh);
+		waist.add(this.lowerBody);
+
+		this.waist = waist;
+		this.add(waist);
 
 		// ===== Right Arm (upper + elbow + lower) =====
 		const rightUpperArmBox = new BoxGeometry(); // 1x1x1, we scale it
@@ -577,9 +601,13 @@ export class SkinObject extends Group {
 		this.leftLowerLegPivot.position.set(0, -4, 0);
 
 		// BodyPart containers place the pivots in world
-		this.body.rotation.set(0, 0, 0);
+		this.upperBody.rotation.set(0, 0, 0);
+		this.lowerBody.rotation.set(0, 0, 0);
+		this.waist.rotation.set(0, 0, 0);
 		this.head.position.y = 0;
-		this.body.position.set(0, -6, 0);
+		this.waist.position.set(0, -6, 0);
+		this.upperBody.position.set(0, 0, 0);
+		this.lowerBody.position.set(0, 0, 0);
 
 		this.rightLowerArm.position.set(0, 0, 0);
 		this.leftLowerArm.position.set(0, 0, 0);


### PR DESCRIPTION
## Summary
- replace `body` with `upperBody` and `lowerBody` on a waist pivot
- expose new torso joints in examples and bone selector
- document torso migration in README

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b67b469fc8327822c42e932af1ec4