### PR TITLE
feat: enable bone selection via raycasting

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -68,6 +68,7 @@ let ikUpdateId: number | null = null;
 let jointHelpers: BoxHelper[] = [];
 const extraPlayers: skinview3d.PlayerObject[] = [];
 let selectionHelper: BoxHelper | null = null;
+let boneSelectionHelper: BoxHelper | null = null;
 const raycaster = new Raycaster();
 const pointer = new Vector2();
 const extraPlayerControls: HTMLElement[] = [];
@@ -208,6 +209,7 @@ function updateJointHelpers(): void {
 		helper.update();
 	}
 	selectionHelper?.update();
+	boneSelectionHelper?.update();
 	requestAnimationFrame(updateJointHelpers);
 }
 updateJointHelpers();
@@ -220,6 +222,20 @@ function getBone(path: string): Object3D {
 		return ikChains[path]?.target ?? selectedPlayer;
 	}
 	return path.split(".").reduce((obj: any, part) => obj?.[part], selectedPlayer) ?? selectedPlayer;
+}
+
+function updateBoneSelectionHelper(): void {
+	if (boneSelectionHelper) {
+		skinViewer.scene.remove(boneSelectionHelper);
+		boneSelectionHelper = null;
+	}
+	if (!editorEnabled) {
+		return;
+	}
+	const bone = getBone(selectedBone);
+	boneSelectionHelper = new BoxHelper(bone, 0xff00ff);
+	boneSelectionHelper.update();
+	skinViewer.scene.add(boneSelectionHelper);
 }
 
 function updateViewportSize(): void {
@@ -256,6 +272,7 @@ function selectPlayer(player: skinview3d.PlayerObject | null): void {
 	if (editorEnabled) {
 		setupIK();
 	}
+	updateBoneSelectionHelper();
 	for (const part of skinParts) {
 		const skinPart = (selectedPlayer.skin as any)[part];
 		for (const layer of skinLayers) {
@@ -288,6 +305,39 @@ function handlePlayerClick(event: MouseEvent): void {
 	pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
 	pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
 	raycaster.setFromCamera(pointer, skinViewer.camera);
+	if (editorEnabled) {
+		const map = new Map<Object3D, string>();
+		for (const part of skinParts) {
+			const bone = (selectedPlayer.skin as any)[part] as Object3D | undefined;
+			if (bone) {
+				map.set(bone, `skin.${part}`);
+			}
+		}
+		for (const key of Object.keys(ikChains)) {
+			map.set(ikChains[key].target, key);
+		}
+		const objects = Array.from(map.keys());
+		const intersections = raycaster.intersectObjects(objects, true);
+		if (intersections.length > 0) {
+			let obj = intersections[0].object as Object3D | null;
+			while (obj && !map.has(obj)) {
+				obj = obj.parent as Object3D | null;
+			}
+			const path = obj ? map.get(obj) : undefined;
+			if (path) {
+				selectedBone = path;
+				if (boneSelector) {
+					boneSelector.value = path;
+					boneSelector.focus();
+				}
+				if (transformControls) {
+					transformControls.attach(getBone(selectedBone));
+				}
+				updateBoneSelectionHelper();
+				return;
+			}
+		}
+	}
 	const players = [skinViewer.playerObject, ...extraPlayers];
 	let hit: skinview3d.PlayerObject | null = null;
 	for (const p of players) {
@@ -1309,6 +1359,7 @@ function toggleEditor(): void {
 		}
 		transformControls.attach(getBone(selectedBone));
 		skinViewer.scene.add(transformControls);
+		updateBoneSelectionHelper();
 	} else {
 		skinViewer.autoRotate = previousAutoRotate;
 		const anim = skinViewer.getAnimation(selectedPlayer);
@@ -1326,6 +1377,7 @@ function toggleEditor(): void {
 		disposeIK();
 		initializeBoneSelector(false);
 		selectedBone = boneSelector?.value || "playerObject";
+		updateBoneSelectionHelper();
 	}
 }
 
@@ -1499,6 +1551,7 @@ boneSelector?.addEventListener("change", () => {
 	if (transformControls) {
 		transformControls.attach(getBone(selectedBone));
 	}
+	updateBoneSelectionHelper();
 });
 const toggleEditorBtn = document.getElementById("toggle_editor");
 toggleEditorBtn?.addEventListener("click", toggleEditor);


### PR DESCRIPTION
## Summary
- allow editor clicks to pick individual bones and IK target spheres
- focus bone selector, reattach controls, and highlight the chosen element

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b67b531bc832799299e3f9da84317