### PR TITLE
Offset IK controllers to limb ends

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -112,7 +112,10 @@
 				<h1>Animation Editor</h1>
 				<button id="toggle_editor" type="button" class="control">Create Animation</button>
 				<div id="animation_editor" class="hidden">
-					<p class="control">Select an IK controller and drag its colored sphere in the viewer to pose the limb.</p>
+					<p class="control">
+						Select an IK controller and drag its colored sphere in the viewer to pose the limb. Controllers are offset
+						along the limb's forward direction so the spheres sit at the limb's end.
+					</p>
 					<label class="control">
 						Bone:
 						<select id="bone_selector">

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -8,6 +8,7 @@ import {
 	Mesh,
 	MeshBasicMaterial,
 	Object3D,
+	Quaternion,
 	Raycaster,
 	SphereGeometry,
 	Vector2,
@@ -630,6 +631,11 @@ function setupIK(): void {
 	rightLowerArmTarget.add(rightLowerArmMesh);
 
 	rightLowerArmTarget.position.copy(skin.rightLowerArm.getWorldPosition(new Vector3()));
+	rightLowerArmTarget.position.add(
+		new Vector3(0, -4, 0)
+			.multiplyScalar(selectedPlayer.scale.y)
+			.applyQuaternion(skin.rightLowerArm.getWorldQuaternion(new Quaternion()))
+	);
 	skinViewer.scene.add(rightLowerArmTarget);
 	const rIK = new IK();
 	const rChain = new IKChain();
@@ -651,6 +657,11 @@ function setupIK(): void {
 	leftLowerArmTarget.add(leftLowerArmMesh);
 
 	leftLowerArmTarget.position.copy(skin.leftLowerArm.getWorldPosition(new Vector3()));
+	leftLowerArmTarget.position.add(
+		new Vector3(0, -4, 0)
+			.multiplyScalar(selectedPlayer.scale.y)
+			.applyQuaternion(skin.leftLowerArm.getWorldQuaternion(new Quaternion()))
+	);
 	skinViewer.scene.add(leftLowerArmTarget);
 	const lIK = new IK();
 	const lChain = new IKChain();
@@ -673,6 +684,11 @@ function setupIK(): void {
 	rightLowerLegTarget.add(rightLowerLegMesh);
 
 	rightLowerLegTarget.position.copy(skin.rightLowerLeg.getWorldPosition(new Vector3()));
+	rightLowerLegTarget.position.add(
+		new Vector3(0, -4, 0)
+			.multiplyScalar(selectedPlayer.scale.y)
+			.applyQuaternion(skin.rightLowerLeg.getWorldQuaternion(new Quaternion()))
+	);
 	skinViewer.scene.add(rightLowerLegTarget);
 	const rLegIK = new IK();
 	const rLegChain = new IKChain();
@@ -695,6 +711,11 @@ function setupIK(): void {
 	leftLowerLegTarget.add(leftLowerLegMesh);
 
 	leftLowerLegTarget.position.copy(skin.leftLowerLeg.getWorldPosition(new Vector3()));
+	leftLowerLegTarget.position.add(
+		new Vector3(0, -4, 0)
+			.multiplyScalar(selectedPlayer.scale.y)
+			.applyQuaternion(skin.leftLowerLeg.getWorldQuaternion(new Quaternion()))
+	);
 	skinViewer.scene.add(leftLowerLegTarget);
 	const lLegIK = new IK();
 	const lLegChain = new IKChain();


### PR DESCRIPTION
## Summary
- Offset IK controller targets along each limb's forward direction so spheres sit at limb tips
- Mention IK controller offset in example documentation

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b67b65e14832798db5f64f754019d