### PR TITLE
Add three-ik type declarations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,5 @@
 		"target": "es2021",
 		"useDefineForClassFields": true
 	},
-	"include": ["src"]
+	"include": ["src", "types"]
 }

--- a/types/three-ik.d.ts
+++ b/types/three-ik.d.ts
@@ -1,0 +1,18 @@
+declare module "three-ik" {
+	import { Object3D } from "three";
+
+	export class IK {
+		add(chain: IKChain): void;
+		solve(): void;
+	}
+
+	export class IKChain {
+		joints: IKJoint[];
+		effectorIndex: number;
+		add(joint: IKJoint, options?: { target?: Object3D }): void;
+	}
+
+	export class IKJoint {
+		constructor(object: Object3D);
+	}
+}


### PR DESCRIPTION
## Summary
- add ambient declarations for IK, IKChain, and IKJoint in three-ik
- include new type declarations via tsconfig

## Testing
- `npm run format`
- `npm test`
- `npm run build:modules`


------
https://chatgpt.com/codex/tasks/task_e_689b6c2d53588327ba83e3ee8a1c64d0