### PR TITLE
Add auto keyframe option to animation editor

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -151,6 +151,7 @@
 					</label>
 					<div id="timeline"></div>
 					<button id="add_keyframe" type="button" class="control">Add Keyframe</button>
+					<label class="control"><input id="auto_keyframe" type="checkbox" /> Auto keyframe</label>
 					<button id="download_json" type="button" class="control">Download JSON</button>
 					<input id="upload_json" type="file" class="control" accept="application/json" />
 					<button id="editor_play_pause" type="button" class="control">Play/Pause</button>

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -71,6 +71,7 @@ let jointHelpers: BoxHelper[] = [];
 const extraPlayers: skinview3d.PlayerObject[] = [];
 let selectionHelper: BoxHelper | null = null;
 let boneSelectionHelper: BoxHelper | null = null;
+let autoKeyframe = false;
 const raycaster = new Raycaster();
 const pointer = new Vector2();
 const extraPlayerControls: HTMLElement[] = [];
@@ -1396,12 +1397,21 @@ function toggleEditor(): void {
 		transformControls = new TransformControls(skinViewer.camera, skinViewer.renderer.domElement);
 		transformControls.addEventListener("dragging-changed", (e: { value: boolean }) => {
 			skinViewer.controls.enabled = !e.value;
-			if (!e.value) {
-				if (selectedBone.startsWith("ik.")) {
-					addIKKeyframe(selectedBone);
-				} else {
-					addKeyframe();
-				}
+		});
+		const addAutoKeyframe = () => {
+			if (!autoKeyframe) {
+				return;
+			}
+			if (selectedBone.startsWith("ik.")) {
+				addIKKeyframe(selectedBone);
+			} else {
+				addKeyframe();
+			}
+		};
+		transformControls.addEventListener("mouseUp", addAutoKeyframe);
+		transformControls.addEventListener("objectChange", () => {
+			if (!transformControls?.dragging) {
+				addAutoKeyframe();
 			}
 		});
 		if (modeSelector) {
@@ -1410,7 +1420,6 @@ function toggleEditor(): void {
 		transformControls.attach(getBone(selectedBone));
 		skinViewer.scene.add(transformControls);
 		snapshotDefaultPose();
-
 	} else {
 		skinViewer.autoRotate = previousAutoRotate;
 		const anim = skinViewer.getAnimation(selectedPlayer);
@@ -1612,6 +1621,11 @@ addKeyframeBtn?.addEventListener("click", () => {
 	} else {
 		addKeyframe();
 	}
+});
+
+const autoKeyframeInput = document.getElementById("auto_keyframe") as HTMLInputElement;
+autoKeyframeInput?.addEventListener("change", () => {
+	autoKeyframe = autoKeyframeInput.checked;
 });
 
 const modeSelector = document.getElementById("transform_mode") as HTMLSelectElement;


### PR DESCRIPTION
## Summary
- add Auto keyframe checkbox near keyframe controls
- auto-insert keyframes after transforming bones or IK targets when enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b8e6550fc8327b0364c8fb3d25182