### PR TITLE
Add reset pose control

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pose and resets orbit controls after you rotate or zoom the view.
 
 Use the **Player** selector to choose which model receives loaded skins, capes, and animations when multiple players are displayed.
 
-While the animation editor is open, use **Reset Pose** to restore the selected player's bones and IK targets to their default state without affecting other players.
+While the animation editor is open, the keyframe controls include a **Reset Pose** button that restores the selected player's bones and IK targets to their default state without affecting other players.
 
 Each texture option (`skin`, `cape`, `ears`, `background`, `panorama`, etc.)
 accepts a URL string, an existing `HTMLImageElement`/`HTMLCanvasElement`, or a

--- a/examples/index.html
+++ b/examples/index.html
@@ -151,10 +151,10 @@
 					</label>
 					<div id="timeline"></div>
 					<button id="add_keyframe" type="button" class="control">Add Keyframe</button>
+					<button id="reset_pose" type="button" class="control">Reset Pose</button>
+					<button id="editor_play_pause" type="button" class="control">Play/Pause</button>
 					<button id="download_json" type="button" class="control">Download JSON</button>
 					<input id="upload_json" type="file" class="control" accept="application/json" />
-					<button id="editor_play_pause" type="button" class="control">Play/Pause</button>
-					<button id="reset_pose" type="button" class="control">Reset Pose</button>
 					<span id="upload_status" class="control hidden"></span>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- reposition reset pose button near keyframe controls in animation editor example
- document reset pose control in README for quick pose restoration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8e66c55083278efbcdaab2ec64eb