### PR TITLE
Wrap resource upload menu in dropdown

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -387,13 +387,17 @@ function createPlayerResourceMenu(player: skinview3d.PlayerObject, index: number
 	animLabel.appendChild(select);
 	div.appendChild(animLabel);
 
+	const dropdown = document.createElement("div");
+	dropdown.className = "dropdown";
 	const uploadBtn = document.createElement("button");
 	uploadBtn.className = "control";
 	uploadBtn.textContent = "Load...";
-	div.appendChild(uploadBtn);
+	dropdown.appendChild(uploadBtn);
 
 	const menu = document.createElement("ul");
-	menu.classList.add("hidden");
+	menu.classList.add("dropdown-menu");
+	dropdown.appendChild(menu);
+	div.appendChild(dropdown);
 
 	function createMenuItem(label: string, accept: string, load: (file: File) => void | Promise<void>): void {
 		const input = document.createElement("input");
@@ -406,7 +410,7 @@ function createPlayerResourceMenu(player: skinview3d.PlayerObject, index: number
 			if (file) {
 				await load(file);
 			}
-			menu.classList.add("hidden");
+			dropdown.classList.remove("open");
 		});
 
 		const item = document.createElement("li");
@@ -442,9 +446,8 @@ function createPlayerResourceMenu(player: skinview3d.PlayerObject, index: number
 		skinViewer.setAnimation(player, anim);
 	});
 
-	div.appendChild(menu);
 	uploadBtn.addEventListener("click", () => {
-		menu.classList.toggle("hidden");
+		dropdown.classList.toggle("open");
 	});
 
 	return div;

--- a/examples/style.css
+++ b/examples/style.css
@@ -47,6 +47,8 @@ input[type="text"] {
 	top: 100%;
 	margin-top: 4px;
 	padding: 4px 0;
+	list-style: none;
+	padding-left: 0;
 	background: #fff;
 	border: 1px solid #ccc;
 	border-radius: 4px;


### PR DESCRIPTION
## Summary
- Wrap resource upload controls in a `.dropdown` div and toggle menu visibility
- Style `.dropdown-menu` list with bullet removal and explicit positioning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ddc3840d883279f092b55a3d3ec82