### PR TITLE
Export joint rotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,10 @@ The `ik` module exposes helpers such as `getTargetRelativePositions` and `export
 for inspecting or exporting target offsets, and `snapTargetToBone` to reset a target to the end of its bone.
 Exported data is returned as JSON, making it easy to tweak or correct coordinates externally.
 
+## Joint Controls
+
+The joint controls example allows repositioning limbs and exporting joint transforms. `exportJointCoordinates()` now returns a JSON object containing each joint's world position and rotation.
+
 # Development Notes
 
 See [viewport-player-resource-notes.md](viewport-player-resource-notes.md) for notes on viewport reset, player selection, and the resource menu, including current pitfalls and unresolved issues.

--- a/examples/index.html
+++ b/examples/index.html
@@ -83,7 +83,7 @@
 			<button id="remove_model" type="button" class="control">Remove Model</button>
 			<button id="change_positioning" type="button" class="control">Change Positioning</button>
 			<button id="toggle_position_controller" type="button" class="control">Toggle Position Controller</button>
-			<button id="export_joint_coordinates" type="button" class="control">Export Joint Coordinates</button>
+			<button id="export_joint_coordinates" type="button" class="control">Export Joint Data</button>
 			<label class="control"
 				>Player:
 				<select id="player_selector"></select

--- a/examples/joint-controls.ts
+++ b/examples/joint-controls.ts
@@ -1,6 +1,6 @@
 import type { SkinViewer, PlayerObject } from "../src/skinview3d";
 import { TransformControls } from "three/examples/jsm/controls/TransformControls.js";
-import { Object3D, Raycaster, Vector2, Vector3 } from "three";
+import { Object3D, Quaternion, Raycaster, Vector2, Vector3 } from "three";
 
 // Augment SkinViewer with joint control helpers
 declare module "../src/viewer" {
@@ -89,11 +89,29 @@ export function attachJointControls(viewer: SkinViewer): void {
 			["leftLowerLeg", skin.leftLowerLegPivot],
 		];
 		const pos = new Vector3();
-		return entries
-			.map(([name, obj]) => {
+		const quat = new Quaternion();
+		const data = Object.fromEntries(
+			entries.map(([name, obj]) => {
 				obj.getWorldPosition(pos);
-				return `${name}: ${pos.x.toFixed(3)} ${pos.y.toFixed(3)} ${pos.z.toFixed(3)}`;
+				obj.getWorldQuaternion(quat);
+				return [
+					name,
+					{
+						position: {
+							x: Number(pos.x.toFixed(3)),
+							y: Number(pos.y.toFixed(3)),
+							z: Number(pos.z.toFixed(3)),
+						},
+						rotation: {
+							x: Number(quat.x.toFixed(3)),
+							y: Number(quat.y.toFixed(3)),
+							z: Number(quat.z.toFixed(3)),
+							w: Number(quat.w.toFixed(3)),
+						},
+					},
+				];
 			})
-			.join("\n");
+		);
+		return JSON.stringify(data, null, 2);
 	};
 }

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -1056,11 +1056,11 @@ function initializeControls(): void {
 	const exportJointBtn = document.getElementById("export_joint_coordinates");
 	exportJointBtn?.addEventListener("click", () => {
 		const data = skinViewer.exportJointCoordinates();
-		const blob = new Blob([data], { type: "text/plain" });
+		const blob = new Blob([data], { type: "application/json" });
 		const url = URL.createObjectURL(blob);
 		const a = document.createElement("a");
 		a.href = url;
-		a.download = "joint-coordinates.txt";
+		a.download = "joint-coordinates.json";
 		a.click();
 		URL.revokeObjectURL(url);
 	});


### PR DESCRIPTION
## Summary
- include world rotation in `exportJointCoordinates` output
- save joint export as JSON and clarify example button text
- document joint controls exporting both position and rotation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689de04161248327a5148e936d9f16e8